### PR TITLE
added code signing and notariziation

### DIFF
--- a/.github/workflows/ccpp_mac_rc.yml
+++ b/.github/workflows/ccpp_mac_rc.yml
@@ -10,7 +10,14 @@ jobs:
   build:
 
     runs-on: macos-12
-
+    env:
+      MACOS_CERTIFICATE: ${{ secrets.MACOS_P12 }}
+      MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_PASSWD }}
+      MACOS_APP_PWD: ${{ secrets.MACOS_NOTARIZATION_PASS }}
+      MACOS_APP_MAIL: ${{ secrets.MACOS_NOTARIZATION_USER }}
+      MACOS_APP_DEVELOPER_ID: ${{ vars.MACOS_APP_DEVELOPER_ID }}
+      MACOS_APP_TEAM_ID: ${{ vars.MACOS_APP_TEAM_ID }}
+      MACOS_KEYCHAIN_TEMP_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_TEMP_PASSWORD }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -22,24 +29,22 @@ jobs:
     - name: relink zstd
       run: install_name_tool -change /usr/local/opt/zstd/lib/libzstd.1.dylib  @executable_path/libzstd.1.dylib ./build/pack/SuperSlicer/SuperSlicer.app/Contents/MacOS/SuperSlicer
     - name: Codesign executable conf
-      env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_P12 }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_PASSWD }}
-          MACOS_APP: ${{ secrets.MAC_APP_PWD }}
       run: |
         echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-        security create-keychain -p temp_password build.keychain
+        security create-keychain -p "$MACOS_KEYCHAIN_TEMP_PASSWORD" build.keychain
         security default-keychain -s build.keychain
-        security unlock-keychain -p temp_password build.keychain
+        security unlock-keychain -p "$MACOS_KEYCHAIN_TEMP_PASSWORD" build.keychain
+        security set-keychain-settings -lut 21600 build.keychain
         security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
     - name: verify certificate presence
       run: security find-identity -v
     - name: register codesign
       run: |
-        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k temp_password build.keychain
+        security set-key-partition-list -S apple-tool:,apple:,codesign:,notarytool: -s -k "$MACOS_KEYCHAIN_TEMP_PASSWORD" build.keychain
     - name: run codesign on exe
       run: |
-        /usr/bin/codesign --deep --options=runtime --force -s "Developer ID Application: Remi Durand (LDTLFRHP3G)" ./build/pack/SuperSlicer/SuperSlicer.app/Contents/MacOS/SuperSlicer -v
+        /usr/bin/codesign --options=runtime --force -s "$MACOS_APP_DEVELOPER_ID" ./build/pack/SuperSlicer/SuperSlicer.app/Contents/MacOS/libzstd.1.dylib
+        /usr/bin/codesign --options=runtime --force -s "$MACOS_APP_DEVELOPER_ID" ./build/pack/SuperSlicer/SuperSlicer.app/Contents/MacOS/SuperSlicer -v
         codesign -vvv --deep --strict ./build/pack/SuperSlicer/SuperSlicer.app/Contents/MacOS/SuperSlicer
         codesign -dvv ./build/pack/SuperSlicer/SuperSlicer.app/Contents/MacOS/SuperSlicer
     - name: create the dmg
@@ -48,21 +53,29 @@ jobs:
         hdiutil convert temp.dmg -format UDZO -o SuperSlicer.dmg
     - name: run codesign on the dmg
       run: |
-        /usr/bin/codesign -s "Developer ID Application: Remi Durand (LDTLFRHP3G)" SuperSlicer.dmg -v
+        /usr/bin/codesign -s "$MACOS_APP_DEVELOPER_ID" SuperSlicer.dmg -v
         codesign -vvv --deep --strict SuperSlicer.dmg
         codesign -dvv SuperSlicer.dmg
+    - name: notarize the dmg
+      run: |
+        xcrun notarytool store-credentials "notarytool-profile" --apple-id "$MACOS_APP_MAIL" --team-id "$MACOS_APP_TEAM_ID" --password "$MACOS_APP_PWD"
+        xcrun notarytool submit "SuperSlicer.dmg" --keychain-profile "notarytool-profile" --wait
+        spctl -a -t open --context context:primary-signature -v SuperSlicer.dmg
     - name: run codesign on app
       run: |
-        /usr/bin/codesign --force -s "Developer ID Application: Remi Durand (LDTLFRHP3G)" ./build/pack/SuperSlicer/SuperSlicer.app -v
+        /usr/bin/codesign --force -s "$MACOS_APP_DEVELOPER_ID" ./build/pack/SuperSlicer/SuperSlicer.app -v
         codesign -vvv --deep --strict ./build/pack/SuperSlicer/SuperSlicer.app
         codesign -dvv ./build/pack/SuperSlicer/SuperSlicer.app
-    - name: Upload artifact
+    - name: run stapler
+      run: |
+        xcrun stapler staple SuperSlicer.dmg
+    - name: Upload App artifact
       uses: actions/upload-artifact@v1.0.0
       with:
         name: rc_macos.app
         path: build/pack/SuperSlicer/SuperSlicer.app
-    - name: Upload artifact
+    - name: Upload DMG artifact
       uses: actions/upload-artifact@v1.0.0
       with:
         name: rc_macos.dmg
-        path: build/SuperSlicer.dmg
+        path: SuperSlicer.dmg

--- a/.github/workflows/ccpp_mac_rc.yml
+++ b/.github/workflows/ccpp_mac_rc.yml
@@ -39,7 +39,7 @@ jobs:
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k temp_password build.keychain
     - name: run codesign on exe
       run: |
-        /usr/bin/codesign --options=runtime --force -s "Developer ID Application: Remi Durand (LDTLFRHP3G)" ./build/pack/SuperSlicer/SuperSlicer.app/Contents/MacOS/SuperSlicer -v
+        /usr/bin/codesign --deep --options=runtime --force -s "Developer ID Application: Remi Durand (LDTLFRHP3G)" ./build/pack/SuperSlicer/SuperSlicer.app/Contents/MacOS/SuperSlicer -v
         codesign -vvv --deep --strict ./build/pack/SuperSlicer/SuperSlicer.app/Contents/MacOS/SuperSlicer
         codesign -dvv ./build/pack/SuperSlicer/SuperSlicer.app/Contents/MacOS/SuperSlicer
     - name: create the dmg
@@ -51,10 +51,6 @@ jobs:
         /usr/bin/codesign -s "Developer ID Application: Remi Durand (LDTLFRHP3G)" SuperSlicer.dmg -v
         codesign -vvv --deep --strict SuperSlicer.dmg
         codesign -dvv SuperSlicer.dmg
-    - name: notarize the dmg
-      run: |
-        xcrun altool --notarize-app -f SuperSlicer.dmg --primary-bundle-id org.slic3r.superslicer -u mail@remidurand.fr -p $MACOS_APP
-        spctl -a -t open --context context:primary-signature -v SuperSlicer.dmg
     - name: run codesign on app
       run: |
         /usr/bin/codesign --force -s "Developer ID Application: Remi Durand (LDTLFRHP3G)" ./build/pack/SuperSlicer/SuperSlicer.app -v


### PR DESCRIPTION
Added codesigning *again* and notarization of dmg file.

Set the following variables and secrets in git
```
MACOS_CERTIFICATE: ${{ secrets.MACOS_P12 }} <- the certificate base64 encoded
MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_PASSWD }} <- the certificate passphrase
MACOS_APP_PWD: ${{ secrets.MACOS_NOTARIZATION_PASS }} <- the apple developer id (application specific) password
MACOS_APP_MAIL: ${{ secrets.MACOS_NOTARIZATION_USER }} <- the apple developer id (email)
MACOS_APP_DEVELOPER_ID: ${{ vars.MACOS_APP_DEVELOPER_ID }} <- the apple developer id subject name (as written in certificate)
MACOS_APP_TEAM_ID: ${{ vars.MACOS_APP_TEAM_ID }} <- the apple id team id used for notarization
MACOS_KEYCHAIN_TEMP_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_TEMP_PASSWORD }} <- a strong random password
```