### PR TITLE
SET_VELOCITY_LIMIT ACCEL_TO_DECEL klipper support added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 [![you can get this shield at shields.io](https://img.shields.io/discord/771316156203270154?color=7289da&logo=discord&logoColor=white)](https://github.com/supermerill/SuperSlicer/issues/611#issuecomment-907833287) [![you can get this shield at shields.io](https://img.shields.io/reddit/subreddit-subscribers/slic3r)](https://reddit.com/r/slic3r) [![you can get this shield at shields.io](https://img.shields.io/github/discussions/supermerill/superslicer)](https://github.com/supermerill/SuperSlicer/discussions)
 
-[![Packaging status](https://repology.org/badge/tiny-repos/superslicer.svg)](https://repology.org/project/superslicer/versions) [![you can get this shield at shields.io](https://img.shields.io/chocolatey/v/superslicer)](https://community.chocolatey.org/packages/superslicer) [![you can get this shield at shields.io](https://img.shields.io/homebrew/cask/v/superslicer)](https://formulae.brew.sh/cask/superslicer) [![you can get this shield at shields.io](https://img.shields.io/archlinux/v/community/x86_64/superslicer)](https://archlinux.org/packages/community/x86_64/superslicer/)
+[![Packaging status](https://repology.org/badge/tiny-repos/superslicer.svg)](https://repology.org/project/superslicer/versions) [![you can get this shield at shields.io](https://img.shields.io/chocolatey/v/superslicer)](https://community.chocolatey.org/packages/superslicer) [![you can get this shield at shields.io](https://img.shields.io/homebrew/cask/v/superslicer)](https://formulae.brew.sh/cask/superslicer) [![you can get this shield at shields.io](https://img.shields.io/archlinux/v/community/x86_64/superslicer)](https://archlinux.org/packages/extra/x86_64/superslicer/)
 # SuperSlicer
 
 **A PrusaSlicer fork (which is a slic3r fork)** (previously Slic3r++)

--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -359,6 +359,8 @@ group:Pressure equalizer (experimental)
 group:label_width$9:sidetext_width$8:Acceleration control (advanced)
 	line:Default acceleration
 		setting:width$4:default_acceleration
+		setting:width$6:deceleration_match_to_er_acceleration
+		setting:width$2:deceleration_factor
 	line:Perimeter acceleration
 		setting:width$4:perimeter_acceleration
 		setting:width$4:external_perimeter_acceleration

--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -359,7 +359,6 @@ group:Pressure equalizer (experimental)
 group:label_width$9:sidetext_width$8:Acceleration control (advanced)
 	line:Default acceleration
 		setting:width$4:default_acceleration
-		setting:width$6:deceleration_match_to_er_acceleration
 		setting:width$2:deceleration_factor
 	line:Perimeter acceleration
 		setting:width$4:perimeter_acceleration

--- a/resources/ui_layout/example/print.ui
+++ b/resources/ui_layout/example/print.ui
@@ -353,7 +353,6 @@ group:Autospeed (advanced)
 group:label_width$9:sidetext_width$8:Acceleration control (advanced)
 	line:Default acceleration
 		setting:width$4:default_acceleration
-		setting:width$6:deceleration_match_to_er_acceleration
 		setting:width$2:deceleration_factor
 	line:Perimeter acceleration
 		setting:width$4:perimeter_acceleration

--- a/resources/ui_layout/example/print.ui
+++ b/resources/ui_layout/example/print.ui
@@ -353,6 +353,8 @@ group:Autospeed (advanced)
 group:label_width$9:sidetext_width$8:Acceleration control (advanced)
 	line:Default acceleration
 		setting:width$4:default_acceleration
+		setting:width$6:deceleration_match_to_er_acceleration
+		setting:width$2:deceleration_factor
 	line:Perimeter acceleration
 		setting:width$4:perimeter_acceleration
 		setting:width$4:external_perimeter_acceleration

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5615,7 +5615,7 @@ std::string GCode::_before_extrude(const ExtrusionPath &path, const std::string 
     // compute speed here to be able to know it for travel_deceleration_use_target
     speed = _compute_speed_mm_per_sec(path, speed);
         
-    if (m_config.travel_deceleration_use_target){
+    if (m_config.travel_deceleration_use_target == true && m_config.deceleration_factor == 0){
         if (travel_acceleration <= acceleration || travel_acceleration == 0 || acceleration == 0) {
             m_writer.set_travel_acceleration((uint32_t)floor(acceleration + 0.5));
             m_writer.set_acceleration((uint32_t)floor(acceleration + 0.5));
@@ -5630,7 +5630,7 @@ std::string GCode::_before_extrude(const ExtrusionPath &path, const std::string 
                 Polyline poly_start = this->travel_to(gcode, path.first_point(), path.role());
                 coordf_t length = poly_start.length();
                 // compute some numbers
-                double previous_accel = m_writer.get_acceleration(); // in mm/s²
+                double previous_accel = m_writer.get_acceleration(); // in mm/s² // isn't used anywhere?
                 double previous_speed = m_writer.get_speed(); // in mm/s
                 double travel_speed = m_config.get_computed_value("travel_speed");
                 // first, the acceleration distance

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5614,9 +5614,9 @@ std::string GCode::_before_extrude(const ExtrusionPath &path, const std::string 
 
     // compute speed here to be able to know it for travel_deceleration_use_target
     speed = _compute_speed_mm_per_sec(path, speed);
-        
-    if (m_config.travel_deceleration_use_target == true && m_config.deceleration_factor == 0){
+    if (m_config.travel_deceleration_use_target == true && m_config.gcode_flavor != gcfKlipper){
         if (travel_acceleration <= acceleration || travel_acceleration == 0 || acceleration == 0) {
+            //m_writer.set_travel_acceleration((uint32_t)floor(travel_acceleration + 0.5));
             m_writer.set_travel_acceleration((uint32_t)floor(acceleration + 0.5));
             m_writer.set_acceleration((uint32_t)floor(acceleration + 0.5));
             // go to first point of extrusion path (stop at midpoint to let us set the decel speed)
@@ -5633,6 +5633,7 @@ std::string GCode::_before_extrude(const ExtrusionPath &path, const std::string 
                 double previous_accel = m_writer.get_acceleration(); // in mm/s² // isn't used anywhere?
                 double previous_speed = m_writer.get_speed(); // in mm/s
                 double travel_speed = m_config.get_computed_value("travel_speed");
+                double deccel_factor = m_config.get_computed_value("deceleration_factor");
                 // first, the acceleration distance
                 const double extrude2travel_speed_diff = previous_speed >= travel_speed ? 0 : (travel_speed - previous_speed);
                 const double seconds_to_go_travel_speed = (extrude2travel_speed_diff / travel_acceleration);
@@ -5666,6 +5667,7 @@ std::string GCode::_before_extrude(const ExtrusionPath &path, const std::string 
                 // don't use it if the travel speed isn't high enough vs next speed
                 cant_use_deceleration = cant_use_deceleration || dist_to_go_extrude_speed < coordf_t(SCALED_EPSILON);
                 if (cant_use_deceleration) {
+                    //m_writer.set_travel_acceleration((uint32_t)floor(travel_acceleration + 0.5)); ?
                     m_writer.set_travel_acceleration((uint32_t)floor(acceleration + 0.5));
                     m_writer.set_acceleration((uint32_t)floor(acceleration + 0.5));
                     this->write_travel_to(gcode, poly_start, "move to first " + description + " point (minimum acceleration)");
@@ -5699,7 +5701,8 @@ std::string GCode::_before_extrude(const ExtrusionPath &path, const std::string 
                         this->write_travel_to(gcode, poly_start, "move to first " + description + " point (acceleration)");
                         //travel acceleration should be already set at startup via special gcode, and so it's automatically used by G0.
                         gcode += "; decel to extrusion\n";
-                        m_writer.set_travel_acceleration((uint32_t)floor(acceleration + 0.5));
+                        m_writer.set_travel_acceleration((uint32_t)floor(travel_acceleration * deccel_factor ));
+                        //m_writer.set_acceleration((uint32_t)floor(acceleration * deccel_factor ));
                         this->write_travel_to(gcode, poly_end, "move to first " + description + " point (deceleration)");
                         // restore travel accel and ensure the new extrusion accel is set
                         m_writer.set_travel_acceleration((uint32_t)floor(travel_acceleration + 0.5));
@@ -5707,6 +5710,7 @@ std::string GCode::_before_extrude(const ExtrusionPath &path, const std::string 
                         gcode += "; end travel\n";
                 }
             } else {
+                //m_writer.set_travel_acceleration((uint32_t)floor(travel_acceleration + 0.5));
                 m_writer.set_acceleration((uint32_t)floor(acceleration + 0.5));
             }
         }

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -297,6 +297,7 @@ void GCodeWriter::set_travel_acceleration(uint32_t acceleration)
         return;
 
     m_current_travel_acceleration = acceleration;
+    m_current_acceleration = acceleration;// theres a bug with this, setting travel accel needs to reset the current accel so it can get written.
 }
 
 uint32_t GCodeWriter::get_acceleration() const
@@ -305,7 +306,7 @@ uint32_t GCodeWriter::get_acceleration() const
 }
 
 std::string GCodeWriter::write_acceleration(){
-    if (m_current_acceleration == m_last_acceleration || m_current_acceleration == 0)
+    if (m_current_acceleration == m_last_acceleration || m_current_acceleration == 0 /*|| m_current_acceleration == m_current_travel_acceleration*/ )
         return "";
 
     m_last_acceleration = m_current_acceleration;

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -324,7 +324,7 @@ std::string GCodeWriter::write_acceleration(){
         // M204: Set printing & travel acceleration
         gcode << "M204 P" << m_current_acceleration << " T" << (m_current_travel_acceleration > 0 ? m_current_travel_acceleration : m_current_acceleration);
     } else if (FLAVOR_IS(gcfKlipper)){
-        if (this->config.deceleration_match_to_er_acceleration == true){
+        if (this->config.deceleration_factor > 0){
             gcode << "SET_VELOCITY_LIMIT ACCEL=" << m_current_acceleration <<" ACCEL_TO_DECEL=" << m_current_acceleration * this->config.deceleration_factor.value / 100 /*<< " SQUARE_CORNER_VELOCITY="*/; //GUI will need to be "cleaned up" before adding in square corner feature since it will add ~12 boxes.
         }
         else{

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -21,6 +21,8 @@ public:
         multiple_extruders(false), m_extrusion_axis("E"), m_tool(nullptr),
         m_single_extruder_multi_material(false),
         m_last_acceleration(0), m_current_acceleration(0), m_current_speed(0),
+        m_current_travel_acceleration(0),m_last_fan_speed(0), m_last_temperature(0),m_last_temperature_with_offset(0),//stops a couple compiler warnings
+        m_last_pressure(0), m_current_pressure(0),
         m_last_bed_temperature(0), m_last_bed_temperature_reached(true), 
         m_lifted(0)
         {}
@@ -48,8 +50,10 @@ public:
     std::string set_bed_temperature(uint32_t temperature, bool wait = false);
     void        set_acceleration(uint32_t acceleration);
     void        set_travel_acceleration(uint32_t acceleration);
+    void        set_pressure(double pressure);
     uint32_t    get_acceleration() const;
     std::string write_acceleration();
+    std::string write_pressure();
     std::string reset_e(bool force = false);
     std::string update_progress(uint32_t num, uint32_t tot, bool allow_100 = false) const;
     // return false if this extruder was already selected
@@ -103,6 +107,8 @@ private:
     uint32_t        m_current_acceleration;
     uint32_t        m_current_travel_acceleration;
     double          m_current_speed;
+    double          m_current_pressure;
+    double          m_last_pressure;
     uint8_t         m_last_fan_speed;
     int16_t         m_last_temperature;
     int16_t         m_last_temperature_with_offset;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -572,6 +572,8 @@ static std::vector<std::string> s_Preset_print_options {
         "top_solid_infill_acceleration",
         "travel_acceleration",
         "travel_deceleration_use_target",
+        "deceleration_match_to_er_acceleration",
+        "deceleration_factor",
         // skirt
         "skirts",
         "skirt_distance",

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -572,7 +572,6 @@ static std::vector<std::string> s_Preset_print_options {
         "top_solid_infill_acceleration",
         "travel_acceleration",
         "travel_deceleration_use_target",
-        "deceleration_match_to_er_acceleration",
         "deceleration_factor",
         // skirt
         "skirts",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -199,7 +199,6 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver& /* ne
         "threads",
         "travel_acceleration",
         "travel_deceleration_use_target",
-        "deceleration_match_to_er_acceleration",
         "deceleration_factor",
         "travel_speed",
         "travel_speed_z",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -199,6 +199,8 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver& /* ne
         "threads",
         "travel_acceleration",
         "travel_deceleration_use_target",
+        "deceleration_match_to_er_acceleration",
+        "deceleration_factor",
         "travel_speed",
         "travel_speed_z",
         "use_firmware_retraction",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5883,17 +5883,10 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Decelerate with travel acceleration");
     def->full_label = L("Use target acceleration for travel deceleration");
     def->category = OptionCategory::speed;
-    def->tooltip = L("If selected, the travel move going to start the extrusion will use this acceleration value.");
-    def->mode = comExpert | comSuSi;
-    def->set_default_value(new ConfigOptionBool(true));
-
-    def = this->add("deceleration_match_to_er_acceleration", coBool);
-    def->label = L("Enable ER deceleration");
-    def->full_label = L("Use factor of ER acceleration for decelerations");
-    def->category = OptionCategory::speed;
-    def->tooltip = L("If enabled gcode will set the deceleration value to deceleration_factor of the extrusion roles acceleration value, if disabled it will continue to use the firmwares deceleration value. "
-                    "\n this is mainly used for klippers InputShaping algorithm"
-                    "\n note: only supported with klipper firmware!");
+    //def->tooltip = L("If selected, the deceleration of a travel will use the acceleration value of the extrusion that will be printed after it (if any) ")
+    def->tooltip = L("if enabled, the travel move will use the upcoming extrusion roles acceleration value as the travel acceleration value before it starts the extrusion role"
+                     "\nit inserts the acceleration change at the 'midway' point of the travel move"
+                     "\nthis might help with 'ringing' artifacts that get generated from travel moves");
     def->mode = comExpert | comSuSi;
     def->set_default_value(new ConfigOptionBool(true));
 
@@ -5902,9 +5895,11 @@ void PrintConfigDef::init_fff_params()
     def->full_label = L("Use percentage of ER acceleration for decelerations");
     def->category = OptionCategory::speed;
     def->tooltip = L("choose your deceration rate"
+                    "\n set 0 to disable \tNOTE: only supported with klipper firmware!"
+                    "\nIf higher than 0 sliced gcode will set the deceleration value to deceleration_factor of the extrusion roles acceleration value, if disabled it will continue to use the firmwares deceleration value for all declerations"
                     "\nthis is mainly used for klippers InputShaping algorithm"
                     "\nfeel free to experiment with changing this value and let us know the results.");
-    def->min = 1;
+    def->min = 0;
     def->max = 100;
     def->sidetext = "%";
     def->mode = comExpert | comSuSi;
@@ -7933,7 +7928,6 @@ std::unordered_set<std::string> prusa_export_to_remove_keys = {
 "top_solid_infill_acceleration",
 "travel_acceleration",
 "travel_deceleration_use_target",
-"deceleration_match_to_er_acceleration",
 "deceleration_factor",
 "travel_speed_z",
 "wipe_advanced_algo",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5898,6 +5898,7 @@ void PrintConfigDef::init_fff_params()
                     "\n set 0 to disable \tNOTE: only supported with klipper firmware!"
                     "\nIf higher than 0 sliced gcode will set the deceleration value to deceleration_factor of the extrusion roles acceleration value, if disabled it will continue to use the firmwares deceleration value for all declerations"
                     "\nthis is mainly used for klippers InputShaping algorithm"
+                    "\n for marlin firmware this only adjust the deceleration rate for travel movements"
                     "\nfeel free to experiment with changing this value and let us know the results.");
     def->min = 0;
     def->max = 100;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5880,12 +5880,35 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionFloatOrPercent(1500, false));
 
     def = this->add("travel_deceleration_use_target", coBool);
-    def->label = L("Decelerate with target acceleration");
+    def->label = L("Decelerate with travel acceleration");
     def->full_label = L("Use target acceleration for travel deceleration");
     def->category = OptionCategory::speed;
-    def->tooltip = L("If selected, the deceleration of a travel will use the acceleration value of the extrusion that will be printed after it (if any) ");
+    def->tooltip = L("If selected, the travel move going to start the extrusion will use this acceleration value.");
     def->mode = comExpert | comSuSi;
     def->set_default_value(new ConfigOptionBool(true));
+
+    def = this->add("deceleration_match_to_er_acceleration", coBool);
+    def->label = L("Enable ER deceleration");
+    def->full_label = L("Use factor of ER acceleration for decelerations");
+    def->category = OptionCategory::speed;
+    def->tooltip = L("If enabled gcode will set the deceleration value to deceleration_factor of the extrusion roles acceleration value, if disabled it will continue to use the firmwares deceleration value. "
+                    "\n this is mainly used for klippers InputShaping algorithm"
+                    "\n note: only supported with klipper firmware!");
+    def->mode = comExpert | comSuSi;
+    def->set_default_value(new ConfigOptionBool(true));
+
+    def = this->add("deceleration_factor", coPercent);
+    def->label = L("Deceleration factor");
+    def->full_label = L("Use percentage of ER acceleration for decelerations");
+    def->category = OptionCategory::speed;
+    def->tooltip = L("choose your deceration rate"
+                    "\nthis is mainly used for klippers InputShaping algorithm"
+                    "\nfeel free to experiment with changing this value and let us know the results.");
+    def->min = 1;
+    def->max = 100;
+    def->sidetext = "%";
+    def->mode = comExpert | comSuSi;
+    def->set_default_value(new ConfigOptionPercent(50));
 
     def = this->add("travel_speed", coFloat);
     def->label = L("Travel");
@@ -7910,6 +7933,8 @@ std::unordered_set<std::string> prusa_export_to_remove_keys = {
 "top_solid_infill_acceleration",
 "travel_acceleration",
 "travel_deceleration_use_target",
+"deceleration_match_to_er_acceleration",
+"deceleration_factor",
 "travel_speed_z",
 "wipe_advanced_algo",
 "wipe_advanced_multiplier",

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1106,7 +1106,6 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionString,              color_change_gcode))
     ((ConfigOptionString,              pause_print_gcode))
     ((ConfigOptionString,              template_custom_gcode))
-    ((ConfigOptionBool,                deceleration_match_to_er_acceleration))
     ((ConfigOptionPercent,             deceleration_factor))
 
 )

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1106,6 +1106,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionString,              color_change_gcode))
     ((ConfigOptionString,              pause_print_gcode))
     ((ConfigOptionString,              template_custom_gcode))
+    ((ConfigOptionBool,                deceleration_match_to_er_acceleration))
+    ((ConfigOptionPercent,             deceleration_factor))
 
 )
 #ifdef HAS_PRESSURE_EQUALIZER

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -540,7 +540,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
         toggle_field(el, config->opt_bool("milling_post_process"));
 
     bool have_default_acceleration = config->option<ConfigOptionFloatOrPercent>("default_acceleration")->value > 0;
-    bool have_decleration_enabled =  config->option<ConfigOptionBool>("deceleration_match_to_er_acceleration")->value;
+    bool have_decleration_enabled =  config->option<ConfigOptionPercent>("deceleration_factor")->value <= 0;
     for (auto el : { "perimeter_acceleration", "external_perimeter_acceleration", "thin_walls_acceleration" })
         toggle_field(el, have_default_acceleration && have_perimeters);
     toggle_field("infill_acceleration", have_default_acceleration && have_infill);
@@ -550,11 +550,11 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     toggle_field("support_material_acceleration", have_default_acceleration && (have_support_material || have_brim || have_skirt));
     toggle_field("support_material_interface_acceleration", have_default_acceleration && have_support_material && have_support_interface);
     toggle_field("brim_acceleration", have_default_acceleration && (have_brim || have_skirt));
-    toggle_field("deceleration_match_to_er_acceleration", have_default_acceleration);// i guess this is enough checks? is there other firmware that supports decleration values ? and is it better to leave the firmware check for in gcodewriter?
-    toggle_field("deceleration_factor", have_default_acceleration && have_decleration_enabled);
+    toggle_field("deceleration_factor", have_default_acceleration);// i guess this is enough checks? is there other firmware that supports decleration values ? and is it better to leave the firmware check for in gcodewriter?
     for (auto el : { "bridge_acceleration", "bridge_internal_acceleration", "overhangs_acceleration", "gap_fill_acceleration", "travel_acceleration", "travel_deceleration_use_target", "first_layer_acceleration" })
         toggle_field(el, have_default_acceleration);
 
+    toggle_field("travel_deceleration_use_target", have_default_acceleration && have_decleration_enabled );
     // for default speed, it needs at least a dependent field with a %
     toggle_field("default_speed", config->option<ConfigOptionFloatOrPercent>("perimeter_speed")->percent || 
         config->option<ConfigOptionFloatOrPercent>("solid_infill_speed")->percent || 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -540,6 +540,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
         toggle_field(el, config->opt_bool("milling_post_process"));
 
     bool have_default_acceleration = config->option<ConfigOptionFloatOrPercent>("default_acceleration")->value > 0;
+    bool have_decleration_enabled =  config->option<ConfigOptionBool>("deceleration_match_to_er_acceleration")->value;
     for (auto el : { "perimeter_acceleration", "external_perimeter_acceleration", "thin_walls_acceleration" })
         toggle_field(el, have_default_acceleration && have_perimeters);
     toggle_field("infill_acceleration", have_default_acceleration && have_infill);
@@ -549,6 +550,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     toggle_field("support_material_acceleration", have_default_acceleration && (have_support_material || have_brim || have_skirt));
     toggle_field("support_material_interface_acceleration", have_default_acceleration && have_support_material && have_support_interface);
     toggle_field("brim_acceleration", have_default_acceleration && (have_brim || have_skirt));
+    toggle_field("deceleration_match_to_er_acceleration", have_default_acceleration);// i guess this is enough checks? is there other firmware that supports decleration values ? and is it better to leave the firmware check for in gcodewriter?
+    toggle_field("deceleration_factor", have_default_acceleration && have_decleration_enabled);
     for (auto el : { "bridge_acceleration", "bridge_internal_acceleration", "overhangs_acceleration", "gap_fill_acceleration", "travel_acceleration", "travel_deceleration_use_target", "first_layer_acceleration" })
         toggle_field(el, have_default_acceleration);
 


### PR DESCRIPTION
gcode now emits SET_VELOCITY_LIMIT ACCEL ACCEL_TO_DECEL instead of m204 commands with the deceleration value.
users can now choose a % of the extrusion roles deceleration value from 1% 10 100% of the extrusions roles acceleration value.

currently klipper's base deceleration values are set in the firmware, if it's at 50k there it will use 50k for all deceleration moves regardless of acceleration value set by m204/SET_VELOCITY_LIMIT.

i'm unsure if "ACCEL_TO_DECEL" is needed for input shaper to work correctly 

"work arounds" are using custom_gcode - in between extrusion role changes or a klipper macro
"work arounds" are mentioned a fair bit in Voron discord