### PR TITLE
Automatic builds for apple silicon fix 

### DIFF
--- a/.github/workflows/ccpp_mac_arm.yml
+++ b/.github/workflows/ccpp_mac_arm.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-11
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ccpp_mac_arm_debug.yml
+++ b/.github/workflows/ccpp_mac_arm_debug.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-11
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ccpp_mac_arm_rc.yml
+++ b/.github/workflows/ccpp_mac_arm_rc.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-11
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/debug_mac_arm.yml
+++ b/.github/workflows/debug_mac_arm.yml
@@ -1,0 +1,26 @@
+name: C/C++ debug arm macos
+
+on:
+  push:
+    branches:
+      - pr1
+
+jobs:
+  build:
+
+    runs-on: macos-14
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: build deps & slicer
+      run: ./BuildMacOS.sh -ia
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: nightly_macos_arm_debug.dmg
+        path: build/${{ github.event.repository.name }}.dmg
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: nightly_arm_macos.tar
+        path: build/${{ github.event.repository.name }}.tar

--- a/.github/workflows/debug_mac_arm.yml
+++ b/.github/workflows/debug_mac_arm.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: build deps & slicer
-      run: ./BuildMacOS.sh -ia
+      run: ./BuildMacOS.sh -bia
     - name: Upload artifact
       uses: actions/upload-artifact@v1.0.0
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ if(WIN32)
 endif()
 
 if (APPLE)
+    add_compile_options(-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
     message("OS X SDK Path: ${CMAKE_OSX_SYSROOT}")
     if (CMAKE_OSX_DEPLOYMENT_TARGET)
         message("OS X Deployment Target: ${CMAKE_OSX_DEPLOYMENT_TARGET}")

--- a/cmake/modules/FindNLopt.cmake
+++ b/cmake/modules/FindNLopt.cmake
@@ -28,7 +28,7 @@ if(NOT NLopt_DIR)
 
 	set(NLopt_FOUND TRUE)
 
-	set(_NLopt_LIB_NAMES "nlopt")
+	set(_NLopt_LIB_NAMES "nlopt" "nloptd")
 	find_library(NLopt_LIBS
 		NAMES ${_NLopt_LIB_NAMES})
 	if(NOT NLopt_LIBS)

--- a/deps/TIFF/TIFF.cmake
+++ b/deps/TIFF/TIFF.cmake
@@ -6,7 +6,7 @@ if (APPLE)
     if (${CMAKE_OSX_ARCHITECTURES} MATCHES "arm")
         prusaslicer_add_cmake_project(TIFF
             URL https://gitlab.com/libtiff/libtiff/-/archive/v4.3.0/libtiff-v4.3.0.zip
-            URL_HASH SHA256=a1db6826ea1b8b08eaf168973abb29b8a143fb744c1b24cc6967cb12f5e6e81f
+            URL_HASH SHA256=4fca1b582c88319f3ad6ecd5b46320eadaf5eb4ef6f6c32d44caaae4a03d0726
             DEPENDS ${ZLIB_PKG} ${PNG_PKG} dep_JPEG
             CMAKE_ARGS
                 -Dlzma:BOOL=OFF


### PR DESCRIPTION
This small patch solves the problem with iconv not recognised during boost::locale build on apple silicon.

Furthermore it fixes the build on macOS Sonoma with latest Xcode.