### PR TITLE
Fix writing preamble to gcode, desynced gcode viewer (Issue #4036)

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1405,7 +1405,7 @@ void GCode::_do_export(Print& print_mod, GCodeOutputStream &file, ThumbnailsGene
     //klipper can hide gcode into a macro, so add guessed init gcode to the processor.
     if (this->config().start_gcode_manual) {
         std::string gcode = m_writer.preamble();
-        m_processor.process_string(gcode,  this->m_throw_if_canceled);
+        file.write(gcode);
     }
 
     if (! print.config().gcode_substitutions.values.empty()) {


### PR DESCRIPTION
### Describe the issue:
In certain cases, we can see an offset between the displayed gcode and the moves the printhead is taking, as described in #4036.

### What this PR changes:
This PR addresses the underlying issue causing this desync. Specifically, in some printer configurations, certain gcode commands that should be in the beginning of file were not included in the output. This PR fixes that by properly writing these commands to the output.
The cause for the desync was that some internal parts of the code included said commands, while the rendering logic in the gcode viewer did not. More details on the investigation can be found below. The next screenshot shows the feature working as expected once again.
![Screenshot from 2024-07-01 14-47-55](https://github.com/supermerill/SuperSlicer/assets/10976885/e70a3452-60bc-4e4c-9c0a-37ef3683a9da)



### Investigation:
I noticed an offset of 3 steps. I went with printing everything because why not, that always works. Check the screenshot below.
![Screenshot from 2024-07-01 14-47-11](https://github.com/supermerill/SuperSlicer/assets/10976885/e9d1772e-3d91-4a00-930f-3a49c1c2aead)
We can see 3 commands (G21, G90, M83) being processed by the GCodeProcessor, but the .gcode file in the viewer above is missing these commands. The output file is where the gcode preview is based on, hence the offset of 3 commands.

The effects of this bug are even worse when loading the output file in the viewer.
Before this fix: sad cube
![Screenshot from 2024-07-01 15-20-24](https://github.com/supermerill/SuperSlicer/assets/10976885/fad9613a-b158-4c80-aefb-d0349dced700)

After the fix: happy cube
![Screenshot from 2024-07-01 15-21-07](https://github.com/supermerill/SuperSlicer/assets/10976885/c6d24f06-f014-42d4-8d9c-654404ec3f49)



I am not 100% sure that this is how we write the preamble (based on the fact that this unique call on `process_string` was here originally) but judging on [how we write the postamble](https://github.com/supermerill/SuperSlicer/blob/2b8811c975b2ca148eb8ead33d86ba4bc289d804/src/libslic3r/GCode.cpp#L2181) this looks okay. The function `process_string` is now unused and should therefore be deleted.