### PR TITLE
fixes for Mainframe.cpp, CalibrationPressureAdvDialog.cpp, some other corrections, additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ local-lib
 build*
 deps/build*
 deps/deps-*
-
+cmake/CPackConfig.cmake
 # MacOS Ignores
 .DS_Store
 

--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export ROOT=`pwd`
-export NCORES=`nproc --all`
+export NCORES=`nproc`
 FOUND_GTK2=$(dpkg -l libgtk* | grep gtk2)
 FOUND_GTK3=$(dpkg -l libgtk* | grep gtk-3)
 

--- a/resources/calibration/filament_pressure/de_filament_pressure.html
+++ b/resources/calibration/filament_pressure/de_filament_pressure.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Pressure Advance Kalibrierung</title>
+</head>
+<body>
+
+<table width="100%">
+  <tbody>
+  <tr>
+  <td style="text-align: center;">
+    <h1>Pressure/Linear Advance</h1>  
+  </td>
+  </tr>
+  <tr>
+  <td style="text-align: right;"><strong>
+    <table><tr><td>Voraussetzung:</td>
+          <td style="text-align: left;">Bettnivellierung</td>
+          <td style="text-align: left;">Fluss</td>
+          <td style="text-align: left;">Temperatur</td></tr>
+      </table>
+      </strong>
+  </tr>
+  </tbody>
+  </table>
+
+
+<p><strong>Dieser Test befindet sich noch in der Entwicklung, die Beta-Version sollte aber vorerst "gut" funktionieren. 
+  Diese Seite wird zusammen mit ihm aktualisiert werden :)<br> Ihre aktuellen Druckeinstellungen m&uuml;ssen gespeichert werden, bevor
+   Sie auf "Generieren" klicken, da das Programm 
+  die gespeicherten Werte zur Erstellung des Modells verwendet</strong></p>
+<p>Hinweis: Dieser Test zieht automatisch alle aktuell geladenen Konfigurationsparameter und erstellt ein Modell, das Sie 
+  drucken!<br> Um die Geschwindigkeits-/Verarbeitungsbeschr&auml;nkungen der Firmware zu umgehen, ist es empfehlenswert, die meisten 
+  Extrusionsarten auf Geschwindigkeiten zu setzen (aber das muss nicht sein!)</p>
+
+<h2>Wie Sie Ihren Drucker f&uuml;r den Druck/Linearvorschub einstellen</h2>
+<p>F&uuml;r den Anfang</p>
+<ul>
+<li>W&auml;hlen Sie die Anzahl der zu erstellenden Tests aus. Wenn Sie mehr als 1 ausw&auml;hlen, m&uuml;ssen Sie die Gr&ouml;&szlig;e des Fensters 
+  manuell anpassen (klicken und ziehen Sie das Fenster von unten rechts)</li>
+<li>W&auml;hlen Sie die Werte f&uuml;r die Start-/End-/Inkrement-/Extrusionsarten</li>
+<li>jede Zeile ist die Konfiguration f&uuml;r jedes Basistestmodell, z.B.: erste Zeile = externalPerimeter zweite Zeile = firstLayer  </li>
+<li>Da jedes Modell seine eigene Konfiguration hat, kann es sein, dass ein Testmodell schneller/langsamer ist als die anderen, das ist 
+  erwartet und normall</li>
+<li>Ich empfehle, 'first_layer_speed' und 'first_layer_min_speed' auf die gleichen Werte zu setzen </li>
+
+</ul>
+
+<p>Was bedeutet die Option "&Uuml;berpr&uuml;fen"<br>
+  Sie werden feststellen, dass es die Option "&Uuml;berpr&uuml;fen" im Dropdown-Men&uuml; der Extrusionsart gibt, diese Funktion funktioniert derzeit nicht.
+  (Sie k&ouml;nnen sie trotzdem verwenden, aber jede Rolle, die eine L&uuml;ckenf&uuml;llung hat, wird falsch sein und der Test f&uuml;r diese Rolle sollte 
+  ignoriert werden.) <br>
+  Wenn ich es zum Laufen bringe, soll es den Zweck erf&uuml;llen, dass man leicht erkennen kann, welche Extrusionsrollen ihre PA-Werte abstimmen m&uuml;ssen. 
+  Es wird ein Modell f&uuml;r jede ER-Rolle erstellen und die Geschwindigkeit/Beschleunigung/Breite/Abstand dieser Rolle dem einzelnen 
+  Modell<br>
+  Sie k&ouml;nnen dann den Druckvorschubbefehl manuell in das Feld "Pro Region g-code" einf&uuml;gen, aufschneiden und drucken.
+</p>
+
+<h2>Hinweis</h2>
+<p>Bevor Sie diesen Test durchf&uuml;hren, sollten Sie zun&auml;chst alle anderen Einstellungen vornehmen!<br>Ich w&uuml;rde empfehlen, XXXX 
+  auf die gleichen Geschwindigkeiten, XXX auf eine langsame Geschwindigkeit und ebenfalls alles andere, was Sie einstellen k&ouml;nnen.</p>
+<p>Hinweis: Eine gro&szlig;e Varianz bei den ER-Geschwindigkeiten kann die Druckqualit&auml;t/Ma&szlig;haltigkeit beeintr&auml;chtigen; dieser Effekt wird 
+  wird haupts&auml;chlich dadurch verursacht, dass der innere Umfang beim Abk&uuml;hlen n&auml;her an den &auml;u&szlig;eren Umfang gezogen wird, da
+   jeder Umfang eine andere Temperatur hat.</p>
+<p>Ich empfehle, 'first_layer_speed' und 'first_layer_min_speed' auf die gleichen Werte zu setzen </p>
+<p><strong>TODO Dinge &uuml;ber PA und die korrekte Einstellung der ersten Ebene hinzuf&uuml;gen<br>Hinweise zur L&uuml;ftergeschwindigkeit und 
+  Deaktivieren der L&uuml;ftergeschwindigkeit f&uuml;r diesen Test, oder habe ich ein Kontrollk&auml;stchen in der GUI, das automatisch den entsprechenden
+   UI-Reiter &auml;ndert?</strong></p>
+
+   
+<h2>Notiz</h2>
+<p> TODO: Anerkennung f&uuml;r Andrew Ellis' Testmethode hinzuf&uuml;gen</p>
+</body>
+</html>

--- a/resources/calibration/filament_pressure/filament_pressure.html
+++ b/resources/calibration/filament_pressure/filament_pressure.html
@@ -23,36 +23,49 @@
 </tbody>
 </table>
 
-<p><strong>this test is still in development, beta should work "ok" for now though.this page will be get updated along with it :)<br> your current print settings will need to be saved before clicking "generate" since it uses the saved values to create the model</strong></p>
-<p>note: this test will auto pull all your currently loaded config parameters and generate a model for you to print!<br> for to help with firmware speed/processing limitations it's reccomended to have most extrusion roles similar set to speeds.(but you don't have to!)</p>
+<p><strong>This test is still in development, beta should work "ok" for now though. This page will be updated
+   along with it :)<br> your current print settings will need to be saved before clicking "generate" since it uses 
+   the saved values to create the model</strong></p>
+<p>note: this test will auto pull all your currently loaded config parameters and generate a model for you to 
+  print!<br> for to help with firmware speed/processing limitations it's recommended to have most extrusion roles 
+  similar set to speeds.(but you don't have to!)</p>
 
 <h2>How to tune your printer for Pressure/Linear Advance</h2>
 <p>to get started</p>
 <ul>
-<li>select the number of tests to create, if you select more than 1 for now you will have to resize the window manually(click and drag the window from the bottom right)</li>
+<li>select the number of tests to create, if you select more than 1 for now you will have to resize the window 
+  manually(click and drag the window from the bottom right)</li>
 <li>select the start/end/increment/ extrusion role values</li>
-<li>each row is the config for each base test model, eg; first row = externalPerimeter second row = firstLayer </li>
-<li>since each model will have it's own config one test model might be faster/slower than the others, this is expected and normal</li>
-<li>i will reccomend setting 'first_layer_speed' and 'first_layer_min_speed' to the same vales </li>
+<li>each row is the config for each base test model, e.g.: first row = externalPerimeter second row = firstLayer </li>
+<li>since each model will have its own config one test model might be faster/slower than the others, this is 
+  expected and normal</li>
+<li>i will recommend setting 'first_layer_speed' and 'first_layer_min_speed' to the same vales </li>
 
 </ul>
 
 <p>what is this "verify" option?<br>
-you may notice there is the "verify" option in the extrusion role dropdown, this feature currently doesn't work.(you can still use it, but any role that has gap fill will be incorrect and the test for that role should be ignored!) <br>
-when i get it working, it's purpose is to make it easy to see what extrusion roles need it's PA values tuned. 
- it will create a model for each ER role, and assign that roles speed/acceleration/widths/spacing to the single model<br>
+you may notice there is the "verify" option in the extrusion role dropdown, this feature currently doesn't work.
+(you can still use it, but any role that has gap fill will be incorrect and the test for that role should be 
+ignored!) <br>
+when I get it working, its purpose is to make it easy to see what extrusion roles need its PA values tuned. 
+ it will create a model for each ER role, and assign that roles speed/acceleration/widths/spacing to the single 
+ model<br>
 you can then manually add the pressure advance command into the "per region g-code" box, slice and print it.
 </p>
 
 <h2>Advice</h2>
-<p>Before doing this test, it's preferable to tune everything else first!<br>i would reccomended setting XXXX to the same speeds, XXX to a slow speed, and everything else you can send it with.</p>
-<p>note: having large variance with ER speeds can reduce print quality/dimensional accuracy this is effect is mainly caused by the inner perimeter getting pulled closer to the external perimeter as it cools down, since each perimeter would be at different temperatues.</p>
-<p>i will reccomend setting 'first_layer_speed' and 'first_layer_min_speed' to the same vales </p>
-<p><strong>TODO add things about PA and setting first layer correctly<br>add notes about fan speed and disabling fan speed for this test, or do i have check box in GUI that would auto change relavent UI tab?</strong></p>
+<p>Before doing this test, it's preferable to tune everything else first!<br>I would recommend setting XXXX 
+  to the same speeds, XXX to a slow speed, and everything else you can set it with.</p>
+<p>note: having large variance with ER speeds can reduce print quality/dimensional accuracy this is effect is 
+  mainly caused by the inner perimeter getting pulled closer to the external perimeter as it cools down, since
+   each perimeter would be at different temperatures.</p>
+<p>I will recommend setting 'first_layer_speed' and 'first_layer_min_speed' to the same vales </p>
+<p><strong>TODO add things about PA and setting first layer correctly<br>add notes about fan speed and 
+  disabling fan speed for this test, or do i have check box in GUI that would auto change relevant UI tab?</strong></p>
 <ul>
 <li>bullet points</li>
 </ul>
 <h2>Notes</h2>
-<p> TODO: add cred for andrew ellis testing method</p>
+<p> TODO: add cred for Andrew Ellis testing method</p>
 </body>
 </html>

--- a/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
+++ b/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
@@ -1,5 +1,7 @@
 #include "CalibrationPressureAdvDialog.hpp"
 #include "I18N.hpp"
+#include "format.hpp"
+#include "wxExtensions.hpp"
 #include "libslic3r/AppConfig.hpp"
 #include "libslic3r/CustomGCode.hpp"
 #include "libslic3r/Model.hpp"
@@ -211,7 +213,6 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
     std::string nozzle_diameter_str = std::to_string(nozzle_diameter);
     std::replace(nozzle_diameter_str.begin(), nozzle_diameter_str.end(), ',', '.');
     nozzle_diameter_str.erase(nozzle_diameter_str.find_last_not_of('0') + 2, std::string::npos);
-    std::cout << "Nozzle: " << nozzle_diameter_str << std::endl;
     
     if (nozzle_diameter_str.back() == '.') {//if nozzle_diameter_str broke fix it by adding '0' to end, prob not needed?
         nozzle_diameter_str += '0';
@@ -227,8 +228,6 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
 
     std::string bend_90_nozzle_size_3mf = "90_bend_" + nozzle_diameter_str + ".3mf";
     std::string extrusion_role = dynamicExtrusionRole[0]->GetValue().ToStdString();
-
-    std::cout << "currentTestCount: " << currentTestCount << std::endl;
 
     for (int id_item = 0; id_item < currentTestCount; id_item++) {
 
@@ -802,17 +801,19 @@ void CalibrationPressureAdvDialog::create_row_controls(wxBoxSizer* parent_sizer,
 
         wxComboBox* firstPaCombo = new wxComboBox(this, wxID_ANY, wxString{ "0.040" }, wxDefaultPosition, wxDefaultSize, 6, choices_first_layerPA);
         //rowSizer->Add(new wxStaticText(this, wxID_ANY, _L( prefix + " Test " + std::to_string(i) + ": " ))); rowSizer->AddSpacer(5);
-        rowSizer->Add(new wxStaticText(this, wxID_ANY, _L("First Layers" + prefix + "value: ")));
-        firstPaCombo->SetToolTip(_L("Select the first layer" + prefix +" value to be used for the first layer only."));
-        firstPaCombo->SetSelection(3);
-        rowSizer->Add(firstPaCombo);
+        rowSizer->Add(new wxStaticText(this, wxID_ANY, format_wxstr(_L("First Layer %1% value: "), prefix)));
+        firstPaCombo->SetToolTip(format_wxstr(_L("Select the first layer %1% value to be used for the first layer only."), prefix));
+
+
+        firstPaCombo->SetSelection(3); 
+        rowSizer->Add(firstPaCombo);    
         dynamicFirstPa.push_back(firstPaCombo);
 
         rowSizer->AddSpacer(15);
 
         wxComboBox* startPaCombo = new wxComboBox(this, wxID_ANY, wxString{ "0.0" }, wxDefaultPosition, wxDefaultSize, 6, choices_start_PA);
-        rowSizer->Add(new wxStaticText(this, wxID_ANY, _L("Starting" + prefix + "value: ")));
-        startPaCombo->SetToolTip(_L("Select the starting " + prefix + " value to be used."));
+        rowSizer->Add(new wxStaticText(this, wxID_ANY, format_wxstr(_L("Starting %1% value: "),prefix)));
+        startPaCombo->SetToolTip(format_wxstr(_L("Select the starting %1% value to be used."),prefix));
         startPaCombo->SetSelection(0);
         rowSizer->Add(startPaCombo);
         dynamicStartPa.push_back(startPaCombo);
@@ -820,8 +821,8 @@ void CalibrationPressureAdvDialog::create_row_controls(wxBoxSizer* parent_sizer,
         rowSizer->AddSpacer(15);
 
         wxComboBox* endPaCombo = new wxComboBox(this, wxID_ANY, wxString{ "0.10" }, wxDefaultPosition, wxDefaultSize, 10, choices_end_PA);
-        rowSizer->Add(new wxStaticText(this, wxID_ANY, _L("Ending" + prefix + "value: ")));
-        endPaCombo->SetToolTip(_L("Select the ending " + prefix + " value to be used."));
+        rowSizer->Add(new wxStaticText(this, wxID_ANY, format_wxstr(_L("Ending %1% value: "),prefix)));
+        endPaCombo->SetToolTip(format_wxstr(_L("Select the ending %1% value to be used."),prefix));
         endPaCombo->SetSelection(0);
         rowSizer->Add(endPaCombo);
         dynamicEndPa.push_back(endPaCombo);
@@ -829,8 +830,8 @@ void CalibrationPressureAdvDialog::create_row_controls(wxBoxSizer* parent_sizer,
         rowSizer->AddSpacer(15);
 
         wxComboBox* paIncrementCombo = new wxComboBox(this, wxID_ANY, wxString{ "0.005" }, wxDefaultPosition, wxDefaultSize, 8, choices_increment_PA);
-        rowSizer->Add(new wxStaticText(this, wxID_ANY, _L(prefix + "increments: ")));
-        paIncrementCombo->SetToolTip(_L("Select the " + prefix + " increment amount."));
+        rowSizer->Add(new wxStaticText(this, wxID_ANY, format_wxstr(_L("%1% increments: "),prefix)));
+        paIncrementCombo->SetToolTip(format_wxstr(_L("Select the %1% increment amount."),prefix));
         paIncrementCombo->SetSelection(3);
         rowSizer->Add(paIncrementCombo);
         dynamicPaIncrement.push_back(paIncrementCombo);

--- a/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
+++ b/src/slic3r/GUI/CalibrationPressureAdvDialog.cpp
@@ -32,6 +32,19 @@ namespace GUI {
 
 //BUG: custom gcode ' between extrusion role changes' should that be before or after region gcode?
 
+double wxStringToDouble(const wxString& str) {
+    std::string stdStr = std::string(str.mb_str());
+    std::replace(stdStr.begin(), stdStr.end(), ',', '.'); // Ensure dot is used as the decimal separator
+    std::istringstream iss(stdStr);
+    iss.imbue(std::locale("C")); // Use classic "C" locale
+    double value;
+    iss >> value;
+    if (iss.fail()) {
+        throw std::invalid_argument("Invalid number format");
+    }
+    return value;
+}
+
 void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
     /*
     firstPa
@@ -129,7 +142,6 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
     {"FirstLayer", "first_layer_speed"}
     };
 
-
     Plater* plat = this->main_frame->plater();
     Model& model = plat->model();
     if (!plat->new_project(L("Pressure calibration")))
@@ -181,12 +193,10 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
     double spacing_ratio_external = full_print_config.get_computed_value("external_perimeter_overlap");
     double filament_max_overlap = filament_config->get_computed_value("filament_max_overlap",0);//maybe check for extruderID ?
 
-
     // --- translate ---
     //bool autocenter = gui_app->app_config->get("autocenter") == "1";
     bool has_to_arrange = plat->config()->opt_float("init_z_rotate") != 0;
     has_to_arrange = true;
-
     
     /*if (!autocenter) {
         const ConfigOptionPoints* bed_shape = printer_config->option<ConfigOptionPoints>("bed_shape");
@@ -195,13 +205,13 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
         model.objects[objs_idx[0]]->translate({ bed_min.x() + bed_size.x() / 2, bed_min.y() + bed_size.y() / 2, 5 * xyzScale - 5 });
     }*/
     
-
     std::vector < std::vector<ModelObject*>> pressure_tower;
     bool smooth_time = false;
 
     std::string nozzle_diameter_str = std::to_string(nozzle_diameter);
+    std::replace(nozzle_diameter_str.begin(), nozzle_diameter_str.end(), ',', '.');
     nozzle_diameter_str.erase(nozzle_diameter_str.find_last_not_of('0') + 2, std::string::npos);
-
+    std::cout << "Nozzle: " << nozzle_diameter_str << std::endl;
     
     if (nozzle_diameter_str.back() == '.') {//if nozzle_diameter_str broke fix it by adding '0' to end, prob not needed?
         nozzle_diameter_str += '0';
@@ -218,7 +228,10 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
     std::string bend_90_nozzle_size_3mf = "90_bend_" + nozzle_diameter_str + ".3mf";
     std::string extrusion_role = dynamicExtrusionRole[0]->GetValue().ToStdString();
 
+    std::cout << "currentTestCount: " << currentTestCount << std::endl;
+
     for (int id_item = 0; id_item < currentTestCount; id_item++) {
+
         //need to move this to another function.....
         wxString firstPaValue = dynamicFirstPa[id_item]->GetValue();
         wxString startPaValue = dynamicStartPa[id_item]->GetValue();
@@ -227,18 +240,22 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
         wxString erPaValue = dynamicExtrusionRole[id_item]->GetValue();
         smooth_time = dynamicEnableST[id_item]->GetValue();
 
-        double first_pa = wxAtof(firstPaValue);
-        double start_pa = wxAtof(startPaValue);
-        double end_pa = wxAtof(endPaValue);
-        double pa_increment = wxAtof(paIncrementValue);
+        double first_pa, start_pa, end_pa, pa_increment;
+   
+        first_pa = wxStringToDouble(firstPaValue);
+        start_pa = wxStringToDouble(startPaValue);
+        end_pa = wxStringToDouble(endPaValue);
+        pa_increment = wxStringToDouble(paIncrementValue);
         extrusion_role = dynamicExtrusionRole[id_item]->GetValue().ToStdString();
 
         int countincrements = 0;
         int sizeofarray = static_cast<int>((end_pa - start_pa) / pa_increment) + 2;//'+2' needed for odd/even numbers 
+
         std::vector<double> pa_values(sizeofarray);
         std::vector<std::string> c_pa_values_c(sizeofarray);
 
         double incremented_pa_value = start_pa;
+
         while (incremented_pa_value <= end_pa + pa_increment / 2) {//this makes a number to be used to load x number of 90 bend models for the PA test.
             if (incremented_pa_value <= end_pa) {
                 double rounded_Pa = std::round(incremented_pa_value * 1000000.0) / 1000000.0;
@@ -329,7 +346,6 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
         double xy_scaled_number_y = initial_number_y * xyzScale * er_width_to_scale;
         double xy_scaled_point_xy = initial_point_xy * xyzScale * er_width_to_scale;
 
-
         double thickness_offset = nozzle_diameter * er_width_to_scale * 2;
         //double z_scale_90_bend = xyzScale * 1.8 / initial_model_height;
         double z_scale_90_bend = (xyzScale + first_layer_height) / initial_model_height;
@@ -345,8 +361,6 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
             //      this can cause the numbers to not "show up" on the preview because the z scale is calculated wrong.
             // ie; first_layer_height=0.1 and base_layer_height =0.20
             //BUG: if first/base layer height are both .02 numbers don't show up when sliced. doesn't happen with windows, it did for linux ?
-        
-
         
         std::vector<Eigen::Vector3d> bend_90_positions;
         std::vector<Eigen::Vector3d> number_positions;
@@ -487,6 +501,7 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
                 double ypos = ypos_inital;
                 
                 std::string pa_values_string = std::to_string(pa_values[nb_bends]);
+                std::replace(pa_values_string.begin(), pa_values_string.end(), ',', '.');                
                 std::string threemf =".3mf";
             
                 for (int j = 0; j < 7; ++j) {//not sure how the code will respond with a positive array list? ie ; 100.2 this moves decimal point thus breaking the code from loading model since "..3mf" not a real file
@@ -515,6 +530,7 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
             }
         }
     
+
     }
     /// --- main config ---
     // => settings that are for object or region should be added to the model (see below, in the for loop), not here
@@ -539,10 +555,12 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
         wxString erPaValue = dynamicExtrusionRole[id_item]->GetValue();
         smooth_time = dynamicEnableST[id_item]->GetValue();
 
-        double first_pa = wxAtof(firstPaValue);
-        double start_pa = wxAtof(startPaValue);
-        double end_pa = wxAtof(endPaValue);
-        double pa_increment = wxAtof(paIncrementValue);
+        double first_pa, start_pa, end_pa, pa_increment;
+        // Convert std::string to double using std::stod
+        first_pa = wxStringToDouble(firstPaValue);
+        start_pa = wxStringToDouble(startPaValue);
+        end_pa = wxStringToDouble(endPaValue);
+        pa_increment = wxStringToDouble(paIncrementValue);
         extrusion_role = dynamicExtrusionRole[id_item]->GetValue().ToStdString();
 
         int countincrements = 0;
@@ -649,13 +667,19 @@ void CalibrationPressureAdvDialog::create_geometry(wxCommandEvent& event_args) {
             model.objects[objs_idx[id_item]]->volumes[num_part + extra_vol]->config.set_key_value("external_perimeter_acceleration", new ConfigOptionFloatOrPercent(er_accel, false));
             model.objects[objs_idx[id_item]]->volumes[num_part + extra_vol]->config.set_key_value("gap_fill_acceleration", new ConfigOptionFloatOrPercent(er_accel, false));
 
+            std::string first_pa_str = std::to_string(first_pa);
+            std::replace(first_pa_str.begin(), first_pa_str.end(), ',', '.');
+
             if (extrusion_role == "Verify") {
                 model.objects[objs_idx[id_item]]->volumes[num_part + extra_vol]->config.set_key_value("region_gcode", new ConfigOptionString(set_advance_prefix + " ; " + er_role ));//user manual type in values
-                new_printer_config.set_key_value("before_layer_gcode", new ConfigOptionString(std::string("{if layer_num == 0} ") + set_advance_prefix + std::to_string(first_pa) + " {endif}"));
+                new_printer_config.set_key_value("before_layer_gcode", new ConfigOptionString(std::string("{if layer_num == 0} ") + set_advance_prefix + first_pa_str  + " {endif}"));
             }
             else{//add '\n' in?
-                model.objects[objs_idx[id_item]]->volumes[num_part + extra_vol]->config.set_key_value("region_gcode", new ConfigOptionString(set_advance_prefix + std::to_string(pa_values[num_part]) + " ; " + er_role ));
-                new_printer_config.set_key_value("before_layer_gcode", new ConfigOptionString(std::string("{if layer_num == 0} ") + set_advance_prefix + std::to_string(first_pa) + " {endif}"));
+                std::string pa_value_str = std::to_string(pa_values[num_part]);
+                std::replace(pa_value_str.begin(), pa_value_str.end(), ',', '.');
+
+                model.objects[objs_idx[id_item]]->volumes[num_part + extra_vol]->config.set_key_value("region_gcode", new ConfigOptionString(set_advance_prefix + pa_value_str + " ; " + er_role ));
+                new_printer_config.set_key_value("before_layer_gcode", new ConfigOptionString(std::string("{if layer_num == 0} ") + set_advance_prefix + first_pa_str + " {endif}"));
             }
             num_part++;
         }
@@ -728,7 +752,6 @@ void CalibrationPressureAdvDialog::create_buttons(wxStdDialogButtonSizer* button
     GCodeFlavor flavor = printer_config->option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor")->value;
 
     std::string prefix = (gcfMarlinFirmware == flavor) ? " LA " : ((gcfKlipper == flavor || gcfRepRap == flavor) ? " PA " : "unsupported firmware type");
-
 
     if (prefix != "unsupported firmware type") {
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -298,54 +298,50 @@ void MainFrame::update_icon() {
     int icon_size = 0;
     try {
         icon_size = atoi(wxGetApp().app_config->get("tab_icon_size").c_str());
+    } catch (const std::exception& e) {
+        // Handle exception (optional logging)
     }
-    catch (std::exception e) {}
-    switch (m_layout)
-    {
-    case ESettingsLayout::Unknown:
-    {
-        break;
-    } case ESettingsLayout::Old:
-      case ESettingsLayout::Hidden:
-    {
-        if (m_tabpanel->GetPageCount() == 4 && icon_size >= 8) {
-            m_tabpanel->SetPageImage(0, 0);
-            m_tabpanel->SetPageImage(1, 3);
-            m_tabpanel->SetPageImage(2, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 6 : 4);
-            m_tabpanel->SetPageImage(3, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 7 : 5);
-        }
-        break;
-    }
-    case ESettingsLayout::Tabs:
-    {
+
+    switch (m_layout) {
+        case ESettingsLayout::Unknown:
+            break;
+
+        case ESettingsLayout::Old:
+        case ESettingsLayout::Hidden:
+            if (m_tabpanel->GetPageCount() == 4 && icon_size >= 8) {
+                m_tabpanel->SetPageImage(0, 0);
+                m_tabpanel->SetPageImage(1, 3);
+                m_tabpanel->SetPageImage(2, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 6 : 4);
+                m_tabpanel->SetPageImage(3, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 7 : 5);
+            }
+            break;
+
+        case ESettingsLayout::Tabs:
 #ifdef __APPLE__
-        // no icons for macos
-        break;
+            // no icons for macOS
+            break;
 #else
-        if (icon_size >= 8)
-        {
-            m_tabpanel->SetPageImage(0, 0);
-            m_tabpanel->SetPageImage(1, 1);
-            m_tabpanel->SetPageImage(2, 2);
-            m_tabpanel->SetPageImage(3, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 6 : 3);
-            m_tabpanel->SetPageImage(4, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 7 : 4);
-            m_tabpanel->SetPageImage(5, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 8 : 5);
-        }
-        break;
+            if (icon_size >= 8) {
+                m_tabpanel->SetPageImage(0, 0);
+                m_tabpanel->SetPageImage(1, 1);
+                m_tabpanel->SetPageImage(2, 2);
+                m_tabpanel->SetPageImage(3, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 6 : 3);
+                m_tabpanel->SetPageImage(4, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 7 : 4);
+                m_tabpanel->SetPageImage(5, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 8 : 5);
+            }
+            break;
 #endif
-    case ESettingsLayout::Dlg:
-    {
-        if (m_tabpanel->GetPageCount() == 4 && icon_size >= 8) {
-            m_tabpanel->SetPageImage(0, 3);
-            m_tabpanel->SetPageImage(1, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 6 : 4);
-            m_tabpanel->SetPageImage(2, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 7 : 5);
-        }
-        break;
-    }
-    case ESettingsLayout::GCodeViewer:
-    {
-        break;
-    }
+
+        case ESettingsLayout::Dlg:
+            if (m_tabpanel->GetPageCount() == 4 && icon_size >= 8) {
+                m_tabpanel->SetPageImage(0, 3);
+                m_tabpanel->SetPageImage(1, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 6 : 4);
+                m_tabpanel->SetPageImage(2, m_plater->printer_technology() == PrinterTechnology::ptSLA ? 7 : 5);
+            }
+            break;
+
+        case ESettingsLayout::GCodeViewer:
+            break;
     }
 #endif
 }


### PR DESCRIPTION
Some fixes:

CalibrationPressureAdvDialog.cpp: The conversions from string to double depend on locale / language ( , vs. . as delimiter) . Switching to German will cause a crash. This is fixed here.

Mainframe.cpp: fixes setting of braces and #endif

.gitignore: adds cmake/CPackConfig.cmake

filament_pressure.html: some typos corrected

BuildLinux.sh: remove --all from export NCORES=`nproc --all`. When --all is activated too many processes are generated on a virtual machine
