### PR TITLE
New macros variable - layer_used_filament

### DIFF
--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -498,6 +498,7 @@ struct PrintStatistics
     std::string                     initial_filament_type;
     std::string                     printing_filament_types;
     std::map<size_t, double>        filament_stats; // extruder id -> volume in mm3
+    std::map<size_t, double>        total_used_filament_before_current_layer; // extruder id -> mm (length)
 
     std::atomic_bool is_computing_gcode;
 
@@ -520,6 +521,7 @@ struct PrintStatistics
         initial_filament_type.clear();
         printing_filament_types.clear();
         filament_stats.clear();
+        total_used_filament_before_current_layer.clear();
         printing_extruders.clear();
         is_computing_gcode = false;
     }


### PR DESCRIPTION
I cant include my code in `update_print_stats_and_format_filament_stats` on GCode.cpp:1221 because this code executes after file exported.
So I added status variable `total_used_filament_before_current_layer` - this variable contains length of each filament used by printer after code in BEFORE LAYER CHANGE step executed.
This variable is not filled in case of BEFORE LAYER CHANGE custom gcode is empty for optimization reasons, because new macros variable exists in this step only.

This pull request related to issue 4367.