### PR TITLE
Exclude speed ranges (beta release)

### DIFF
--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -345,6 +345,10 @@ group:label_width$8:sidetext_width$7:Speed for print moves
 	line:Wipe tower
 		setting:width$4:label$Main speed:wipe_tower_speed
 		setting:width$4:label$Wipe starting speed:wipe_tower_wipe_starting_speed
+group:Exclude print speeds
+	line:Exclude print speeds (beta)
+        setting:label_width$8:width$4:exclude_print_speed_low
+        setting:label_width$8:width$4:exclude_print_speed_high
 group:Speed for non-print moves
 	line:Travel speed
 		setting:label$xy:travel_speed

--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -345,8 +345,8 @@ group:label_width$8:sidetext_width$7:Speed for print moves
 	line:Wipe tower
 		setting:width$4:label$Main speed:wipe_tower_speed
 		setting:width$4:label$Wipe starting speed:wipe_tower_wipe_starting_speed
-group:Exclude print speeds
-	line:Exclude print speeds (beta)
+group:Exclude print speeds (beta)
+	line:Exclude print speeds
 		setting:label_width$12:width$26:exclude_print_speed_ranges
 		setting:exclude_print_speed_adjustment_direction
 group:Speed for non-print moves

--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -347,8 +347,7 @@ group:label_width$8:sidetext_width$7:Speed for print moves
 		setting:width$4:label$Wipe starting speed:wipe_tower_wipe_starting_speed
 group:Exclude print speeds
 	line:Exclude print speeds (beta)
-        setting:label_width$8:width$4:exclude_print_speed_low
-        setting:label_width$8:width$4:exclude_print_speed_high
+        setting:label_width$8:width$4:exclude_print_speed_ranges
 		setting:exclude_print_speed_move_to_lowest_available_range
 group:Speed for non-print moves
 	line:Travel speed

--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -348,7 +348,7 @@ group:label_width$8:sidetext_width$7:Speed for print moves
 group:Exclude print speeds
 	line:Exclude print speeds (beta)
 		setting:label_width$12:width$26:exclude_print_speed_ranges
-		setting:exclude_print_speed_move_to_lowest_available_range
+		setting:exclude_print_speed_adjustment_direction
 group:Speed for non-print moves
 	line:Travel speed
 		setting:label$xy:travel_speed

--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -349,6 +349,7 @@ group:Exclude print speeds
 	line:Exclude print speeds (beta)
         setting:label_width$8:width$4:exclude_print_speed_low
         setting:label_width$8:width$4:exclude_print_speed_high
+		setting:exclude_print_speed_move_to_lowest_available_range
 group:Speed for non-print moves
 	line:Travel speed
 		setting:label$xy:travel_speed

--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -347,7 +347,7 @@ group:label_width$8:sidetext_width$7:Speed for print moves
 		setting:width$4:label$Wipe starting speed:wipe_tower_wipe_starting_speed
 group:Exclude print speeds
 	line:Exclude print speeds (beta)
-        setting:label_width$8:width$4:exclude_print_speed_ranges
+		setting:label_width$12:width$26:exclude_print_speed_ranges
 		setting:exclude_print_speed_move_to_lowest_available_range
 group:Speed for non-print moves
 	line:Travel speed

--- a/resources/ui_layout/example/print.ui
+++ b/resources/ui_layout/example/print.ui
@@ -338,7 +338,7 @@ group:Speed for non-print moves
 group:Exclude print speeds
 	line:Exclude print speeds (beta)
 		setting:label_width$12:width$26:exclude_print_speed_ranges
-		setting:exclude_print_speed_move_to_lowest_available_range
+		setting:exclude_print_speed_adjustment_direction
 group:sidetext_width$7:Modifiers
 	line:First layer speed
 		setting:label_width$8:width$4:first_layer_min_speed

--- a/resources/ui_layout/example/print.ui
+++ b/resources/ui_layout/example/print.ui
@@ -337,8 +337,7 @@ group:Speed for non-print moves
 	end_line
 group:Exclude print speeds
 	line:Exclude print speeds (beta)
-		setting:label_width$8:width$4:exclude_print_speed_low
-		setting:label_width$8:width$4:exclude_print_speed_high
+		setting:label_width$8:width$4:exclude_print_speed_ranges
 		setting:exclude_print_speed_move_to_lowest_available_range
 group:sidetext_width$7:Modifiers
 	line:First layer speed

--- a/resources/ui_layout/example/print.ui
+++ b/resources/ui_layout/example/print.ui
@@ -339,6 +339,7 @@ group:Exclude print speeds
 	line:Exclude print speeds (beta)
 		setting:label_width$8:width$4:exclude_print_speed_low
 		setting:label_width$8:width$4:exclude_print_speed_high
+		setting:exclude_print_speed_move_to_lowest_available_range
 group:sidetext_width$7:Modifiers
 	line:First layer speed
 		setting:label_width$8:width$4:first_layer_min_speed

--- a/resources/ui_layout/example/print.ui
+++ b/resources/ui_layout/example/print.ui
@@ -335,8 +335,8 @@ group:Speed for non-print moves
 		setting:label$xy:travel_speed
 		setting:label$z:travel_speed_z
 	end_line
-group:Exclude print speeds
-	line:Exclude print speeds (beta)
+group:Exclude print speeds (beta)
+	line:Exclude print speeds
 		setting:label_width$12:width$26:exclude_print_speed_ranges
 		setting:exclude_print_speed_adjustment_direction
 group:sidetext_width$7:Modifiers

--- a/resources/ui_layout/example/print.ui
+++ b/resources/ui_layout/example/print.ui
@@ -335,6 +335,10 @@ group:Speed for non-print moves
 		setting:label$xy:travel_speed
 		setting:label$z:travel_speed_z
 	end_line
+group:Exclude print speeds
+	line:Exclude print speeds (beta)
+		setting:label_width$8:width$4:exclude_print_speed_low
+		setting:label_width$8:width$4:exclude_print_speed_high
 group:sidetext_width$7:Modifiers
 	line:First layer speed
 		setting:label_width$8:width$4:first_layer_min_speed

--- a/resources/ui_layout/example/print.ui
+++ b/resources/ui_layout/example/print.ui
@@ -337,7 +337,7 @@ group:Speed for non-print moves
 	end_line
 group:Exclude print speeds
 	line:Exclude print speeds (beta)
-		setting:label_width$8:width$4:exclude_print_speed_ranges
+		setting:label_width$12:width$26:exclude_print_speed_ranges
 		setting:exclude_print_speed_move_to_lowest_available_range
 group:sidetext_width$7:Modifiers
 	line:First layer speed

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -141,6 +141,8 @@ add_library(libslic3r STATIC
     GCode/GCodeProcessor.hpp
     GCode/AvoidCrossingPerimeters.cpp
     GCode/AvoidCrossingPerimeters.hpp
+    GCode/ExcludePrintSpeeds.cpp
+    GCode/ExcludePrintSpeeds.hpp
     GCode.cpp
     GCode.hpp
     GCodeReader.cpp

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5726,7 +5726,7 @@ double_t GCode::adjust_speed_if_in_forbidden_range(double speed) const
     for (auto range : numeric_ranges) {
         if (speed > range.first && speed < range.second) {
             speed = (move_to_lowest_allowed_speed) ? range.first : range.second;
-            break;
+            return speed;
         }
     }
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5718,6 +5718,7 @@ double_t GCode::_compute_speed_mm_per_sec(const ExtrusionPath& path, double spee
             speed = m_config.get_computed_value("bridge_speed_internal");
         } else if (path.role() == erOverhangPerimeter) {
             speed = m_config.get_computed_value("overhangs_speed");
+            speed = adjust_speed_if_in_forbidden_range(speed);
         } else if (path.role() == erInternalInfill) {
             speed = m_config.get_computed_value("infill_speed");
         } else if (path.role() == erSolidInfill) {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5688,10 +5688,6 @@ double_t GCode::adjust_speed_if_in_forbidden_range(double speed) const
     std::vector<std::string> forbidden_ranges_strings;
     boost::split(forbidden_ranges_strings, forbidden_ranges_user_input, boost::is_any_of(","));
 
-    for (size_t i = 0; i < forbidden_ranges_strings.size(); i++) {
-        std::cout << forbidden_ranges_strings[i] << std::endl;
-    }
-
     // Parse input (check string regex and convert to numeric)
     std::vector<std::pair<int, int>> numeric_ranges;
     auto numeric_range_regex = std::regex("^(\\d+)-(\\d+)$");

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1473,12 +1473,14 @@ void GCode::_do_export(Print& print_mod, GCodeOutputStream &file, ThumbnailsGene
         m_pressure_equalizer = make_unique<PressureEqualizer>(print.config());
     m_enable_extrusion_role_markers = (bool)m_pressure_equalizer;
 
-    if (!print.config().exclude_print_speed_ranges.empty()) {
-        m_exclude_print_speeds =
-            make_unique<ExcludePrintSpeeds>(print.config().exclude_print_speed_ranges,
-                                            print.config().exclude_print_speed_move_to_lowest_available_range);
-    } else {
-        std::cout << "chka46: No ranges set! Not proceeding with ExcludePrintSpeeds initialization" << std::endl;
+    try {
+        if (!print.config().exclude_print_speed_ranges.empty()) {
+            m_exclude_print_speeds =
+                make_unique<ExcludePrintSpeeds>(print.config().exclude_print_speed_ranges,
+                                                print.config().exclude_print_speed_move_to_lowest_available_range);
+        }
+    } catch (std::exception &e) {
+        throw Slic3r::SlicingError(_(L("Error on excluded print speeds:\n") + _(L(e.what()))));
     }
 
     std::string preamble_to_put_start_layer = "";

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5696,16 +5696,14 @@ double_t GCode::adjust_speed_if_in_forbidden_range(double speed) const
     std::vector<std::pair<int, int>> numeric_ranges;
     auto numeric_range_regex = std::regex("^(\\d+)-(\\d+)$");
     for (auto elem : forbidden_ranges_strings) {
-        constexpr size_t LOWER_BOUND_MATCH_INDEX = 1;
-        constexpr size_t UPPER_BOUND_MATCH_INDEX = 2;
-        if (!std::regex_match(elem, numeric_range_regex)) {
-            std::cout << "Range element " << elem << " does not match {int-int} format" << std::endl;
-            break;
+        std::smatch regex_match;
+        if (!std::regex_match(elem, regex_match, numeric_range_regex)) {
+            std::cout << "Range element " << elem << " does not match int-int format" << std::endl;
+            return speed;
         }
 
-        std::smatch regex_match;
-        std::regex_match(elem, regex_match, numeric_range_regex);
-
+        constexpr size_t LOWER_BOUND_MATCH_INDEX = 1;
+        constexpr size_t UPPER_BOUND_MATCH_INDEX = 2;
         auto lower_bound = std::stoi(regex_match[LOWER_BOUND_MATCH_INDEX]);
         auto higher_bound = std::stoi(regex_match[UPPER_BOUND_MATCH_INDEX]);
         if (lower_bound >= higher_bound) {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5719,25 +5719,14 @@ double_t GCode::adjust_speed_if_in_forbidden_range(double speed) const
         int range_end_back = numeric_ranges[i - 1].second;
         if (range_start_front < range_end_back) {
             return speed;
-            /*
-            auto first_range = std::to_string(numeric_ranges[i].first) + "-" +
-                std::to_string(numeric_ranges[i].second);
-            auto second_range = std::to_string(numeric_ranges[i - 1].first) + "-" +
-                std::to_string(numeric_ranges[i - 1].second);
-            std::cout << "Ranges " << first_range << " and " << second_range << " overlap." << std::endl;
-            */
         }
     }
 
     bool move_to_lowest_allowed_speed = m_config.exclude_print_speed_move_to_lowest_available_range.value;
     for (auto range : numeric_ranges) {
         if (speed > range.first && speed < range.second) {
-            // std::string range_str = std::to_string(range.first) + "-" + std::to_string(range.second);
-            // std::cout << "We have an overlap with range " << range_str << std::endl;
             speed = (move_to_lowest_allowed_speed) ? range.first : range.second;
             break;
-            // std::cout << "speed has been " << ((move_to_lowest_allowed_speed) ? "lowered" : "increased") << " to "
-                      // << speed << std::endl;
         }
     }
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5679,7 +5679,7 @@ double_t GCode::adjust_speed_if_in_forbidden_range(double speed) const
     double range_lower_bound = m_config.get_computed_value("exclude_print_speed_low");
     double range_upper_bound = m_config.get_computed_value("exclude_print_speed_high");
     std::pair forbidden_range = {range_lower_bound, range_upper_bound};
-    constexpr bool MOVE_TO_LOWEST_ALLOWED_SPEED = true;
+    bool move_to_lowest_allowed_speed = m_config.exclude_print_speed_move_to_lowest_available_range.value;
 
     if (range_lower_bound != 0.0 && range_upper_bound != 0.0 && range_upper_bound < range_lower_bound) {
         std::cout << "feature not activated or misconfigures, following are set values:" << std::endl;
@@ -5689,8 +5689,8 @@ double_t GCode::adjust_speed_if_in_forbidden_range(double speed) const
 
     if (speed > forbidden_range.first && speed < forbidden_range.second) {
         std::cout << "chka: Set perimeter speed " << speed << " is in forbidden range!" << std::endl;
-        speed = (MOVE_TO_LOWEST_ALLOWED_SPEED) ? forbidden_range.first : forbidden_range.second;
-        std::cout << "speed has been " << ((MOVE_TO_LOWEST_ALLOWED_SPEED) ? "lowered" : "increased") << " to "
+        speed = (move_to_lowest_allowed_speed) ? forbidden_range.first : forbidden_range.second;
+        std::cout << "speed has been " << ((move_to_lowest_allowed_speed) ? "lowered" : "increased") << " to "
                   << speed << std::endl;
     }
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5795,6 +5795,7 @@ double_t GCode::_compute_speed_mm_per_sec(const ExtrusionPath& path, double spee
     // Apply small perimeter 'modifier
     //  don't modify bridge speed
     if (factor < 1 && !(is_bridge(path.role()))) {
+        // TODO - This does not work as expected. Needs to be fixed.
         float small_speed = (float)m_config.small_perimeter_speed.get_abs_value(m_config.get_computed_value("perimeter_speed"));
         if (small_speed > 0)
             //apply factor between feature speed and small speed

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1477,7 +1477,7 @@ void GCode::_do_export(Print& print_mod, GCodeOutputStream &file, ThumbnailsGene
         if (!print.config().exclude_print_speed_ranges.empty()) {
             m_exclude_print_speeds =
                 make_unique<ExcludePrintSpeeds>(print.config().exclude_print_speed_ranges,
-                                                print.config().exclude_print_speed_move_to_lowest_available_range);
+                                                print.config().exclude_print_speed_adjustment_direction);
         }
     } catch (std::exception &e) {
         throw Slic3r::SlicingError(_(L("Error on excluded print speeds:\n") + _(L(e.what()))));

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -517,6 +517,7 @@ private:
     std::string _extrude(const ExtrusionPath &path, const std::string &description, double speed = -1);
     void _extrude_line(std::string& gcode_str, const Line& line, const double e_per_mm, const std::string& comment);
     void _extrude_line_cut_corner(std::string& gcode_str, const Line& line, const double e_per_mm, const std::string& comment, Point& last_pos, const double path_width);
+    double_t adjust_speed_if_in_forbidden_range(double speed) const;
     std::string _before_extrude(const ExtrusionPath &path, const std::string &description, double speed = -1);
     double_t    _compute_speed_mm_per_sec(const ExtrusionPath& path, double speed = -1);
     std::string _after_extrude(const ExtrusionPath &path);

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -11,6 +11,7 @@
 #include "PlaceholderParser.hpp"
 #include "PrintConfig.hpp"
 #include "GCode/AvoidCrossingPerimeters.hpp"
+#include "GCode/ExcludePrintSpeeds.hpp"
 #include "GCode/CoolingBuffer.hpp"
 #include "GCode/FanMover.hpp"
 #include "GCode/FindReplace.hpp"
@@ -485,6 +486,7 @@ private:
     std::unique_ptr<GCodeFindReplace>   m_find_replace;
     std::unique_ptr<PressureEqualizer>  m_pressure_equalizer;
     std::unique_ptr<WipeTowerIntegration> m_wipe_tower;
+    std::unique_ptr<ExcludePrintSpeeds> m_exclude_print_speeds;
 
     // Heights (print_z) at which the skirt has already been extruded.
     std::vector<coordf_t>               m_skirt_done;
@@ -517,7 +519,6 @@ private:
     std::string _extrude(const ExtrusionPath &path, const std::string &description, double speed = -1);
     void _extrude_line(std::string& gcode_str, const Line& line, const double e_per_mm, const std::string& comment);
     void _extrude_line_cut_corner(std::string& gcode_str, const Line& line, const double e_per_mm, const std::string& comment, Point& last_pos, const double path_width);
-    double_t adjust_speed_if_in_forbidden_range(double speed) const;
     std::string _before_extrude(const ExtrusionPath &path, const std::string &description, double speed = -1);
     double_t    _compute_speed_mm_per_sec(const ExtrusionPath& path, double speed = -1);
     std::string _after_extrude(const ExtrusionPath &path);

--- a/src/libslic3r/GCode/ExcludePrintSpeeds.cpp
+++ b/src/libslic3r/GCode/ExcludePrintSpeeds.cpp
@@ -6,11 +6,11 @@
 
 namespace Slic3r {
 
+// TODO - CHKA: Clean code; extract functions
 ExcludePrintSpeeds::ExcludePrintSpeeds(const std::string &_forbidden_ranges_user_input,
-                                       bool               _move_to_lowest_available_speed)
+    const ConfigOptionEnum<ExcludePrintSpeedsAdjustmentDirection> &_adjustment_direction)
 {
-    std::cout << "chka46: initializing ExcludePrintSpeeds" << std::endl;
-    move_to_lowest_allowed_speed            = _move_to_lowest_available_speed;
+    adjustment_direction                    = _adjustment_direction;
     std::string forbidden_ranges_user_input = _forbidden_ranges_user_input;
 
     forbidden_ranges_user_input.erase(std::remove_if(forbidden_ranges_user_input.begin(),
@@ -58,7 +58,24 @@ double_t ExcludePrintSpeeds::adjust_speed_if_in_forbidden_range(double speed)
 {
     for (auto range : forbidden_ranges) {
         if (speed > range.first && speed < range.second) {
-            speed = (move_to_lowest_allowed_speed) ? range.first : range.second;
+            switch (adjustment_direction) {
+            case epsdLowest:
+                speed = range.first;
+                break;
+            case epsdHighest:
+                speed = range.second;
+                break;
+            case epsdNearest:
+                if ((speed - range.first) < (range.second - speed)) {
+                    speed = range.first;
+                } else {
+                    speed = range.second;
+                }
+                break;
+            default:
+                return speed;
+            }
+
             return speed;
         }
     }

--- a/src/libslic3r/GCode/ExcludePrintSpeeds.cpp
+++ b/src/libslic3r/GCode/ExcludePrintSpeeds.cpp
@@ -6,23 +6,33 @@
 
 namespace Slic3r {
 
-// TODO - CHKA: Clean code; extract functions
 ExcludePrintSpeeds::ExcludePrintSpeeds(const std::string &_forbidden_ranges_user_input,
     const ConfigOptionEnum<ExcludePrintSpeedsAdjustmentDirection> &_adjustment_direction)
 {
-    adjustment_direction                    = _adjustment_direction;
-    std::string forbidden_ranges_user_input = _forbidden_ranges_user_input;
+    adjustment_direction = _adjustment_direction;
 
+    std::vector<std::string> excluded_ranges_strings = split_user_input_ranges_to_individual_strings(_forbidden_ranges_user_input);
+    parse_input(excluded_ranges_strings);
+    check_input_correctness(excluded_ranges_strings);
+}
+
+std::vector<std::string> ExcludePrintSpeeds::split_user_input_ranges_to_individual_strings(const std::string &_excluded_ranges_user_input)
+{
+    std::string forbidden_ranges_user_input = _excluded_ranges_user_input;
     forbidden_ranges_user_input.erase(std::remove_if(forbidden_ranges_user_input.begin(),
                                                      forbidden_ranges_user_input.end(), ::isspace),
                                       forbidden_ranges_user_input.end());
 
-    std::vector<std::string> forbidden_ranges_strings;
-    boost::split(forbidden_ranges_strings, forbidden_ranges_user_input, boost::is_any_of(","));
+    std::vector<std::string> excluded_ranges_strings;
+    boost::split(excluded_ranges_strings, forbidden_ranges_user_input, boost::is_any_of(","));
+    return excluded_ranges_strings;
+}
 
-    // Parse input (check string regex and convert to numeric)
+
+void ExcludePrintSpeeds::parse_input(std::vector<std::string> excluded_ranges_strings)
+{
     auto numeric_range_regex = std::regex("^(\\d+)-(\\d+)$");
-    for (const auto &elem : forbidden_ranges_strings) {
+    for (const auto &elem : excluded_ranges_strings) {
         std::smatch regex_match;
         if (!std::regex_match(elem, regex_match, numeric_range_regex)) {
             throw Slic3r::SlicingError("Invalid range " + elem +
@@ -30,25 +40,33 @@ ExcludePrintSpeeds::ExcludePrintSpeeds(const std::string &_forbidden_ranges_user
                                        " separated by \"-\" (example: 30 - 50)");
         }
 
-        constexpr size_t LOWER_BOUND_MATCH_INDEX = 1;
-        constexpr size_t UPPER_BOUND_MATCH_INDEX = 2;
-        auto             lower_bound             = std::stoi(regex_match[LOWER_BOUND_MATCH_INDEX]);
-        auto             higher_bound            = std::stoi(regex_match[UPPER_BOUND_MATCH_INDEX]);
-        if (lower_bound >= higher_bound) {
-            throw Slic3r::SlicingError("Invalid range " + elem + ". Upper bound must be greater than lower bound.");
+        auto lower_bound  = std::stoi(regex_match[LOWER_BOUND_MATCH_INDEX]);
+        auto higher_bound = std::stoi(regex_match[UPPER_BOUND_MATCH_INDEX]);
+        excluded_ranges.emplace_back(lower_bound, higher_bound);
+    }
+}
+
+// TODO - CHKA. The strings here been whitespace-filtered. I want to print the original
+//  user input for HCI reasons. Not strict, might skip doing this.
+void ExcludePrintSpeeds::check_input_correctness(const std::vector<std::string> &excluded_ranges_strings)
+{
+    size_t i = 0;
+    for (const auto &range : excluded_ranges) {
+        if (range.first >= range.second) {
+            throw Slic3r::SlicingError("Invalid range " + excluded_ranges_strings[i] +
+                                       ". Upper bound must be greater than lower bound.");
         }
-        forbidden_ranges.emplace_back(lower_bound, higher_bound);
+        i++;
     }
 
     // Check range consistency (Simply check for overlap. User can enter them in non-ascending lower bound order)
-
-    std::sort(forbidden_ranges.begin(), forbidden_ranges.end(),
+    std::sort(excluded_ranges.begin(), excluded_ranges.end(),
               [](auto &left, auto &right) { return left.first < right.first; });
 
-    for (size_t i = 1; i < forbidden_ranges.size(); i++) {
-        if (forbidden_ranges[i].first < forbidden_ranges[i - 1].second) {
-            throw Slic3r::SlicingError("Ranges " + forbidden_ranges_strings[i - 1] + " and " +
-                                       forbidden_ranges_strings[i] + " overlap.");
+    for (i = 1; i < excluded_ranges.size(); i++) {
+        if (excluded_ranges[i].first < excluded_ranges[i - 1].second) {
+            throw Slic3r::SlicingError("Ranges " + excluded_ranges_strings[i - 1] + " and " +
+                                       excluded_ranges_strings[i] + " overlap.");
         }
     }
 }
@@ -56,7 +74,7 @@ ExcludePrintSpeeds::ExcludePrintSpeeds(const std::string &_forbidden_ranges_user
 
 double_t ExcludePrintSpeeds::adjust_speed_if_in_forbidden_range(double speed)
 {
-    for (auto range : forbidden_ranges) {
+    for (auto range : excluded_ranges) {
         if (speed > range.first && speed < range.second) {
             switch (adjustment_direction) {
             case epsdLowest:

--- a/src/libslic3r/GCode/ExcludePrintSpeeds.cpp
+++ b/src/libslic3r/GCode/ExcludePrintSpeeds.cpp
@@ -1,0 +1,71 @@
+#include "ExcludePrintSpeeds.hpp"
+
+#include <boost/algorithm/string.hpp>
+#include <algorithm>
+#include <regex>
+
+namespace Slic3r {
+
+ExcludePrintSpeeds::ExcludePrintSpeeds(const std::string &_forbidden_ranges_user_input,
+                                       bool               _move_to_lowest_available_speed)
+{
+    std::cout << "chka46: initializing ExcludePrintSpeeds" << std::endl;
+    move_to_lowest_allowed_speed            = _move_to_lowest_available_speed;
+    std::string forbidden_ranges_user_input = _forbidden_ranges_user_input;
+
+    forbidden_ranges_user_input.erase(std::remove_if(forbidden_ranges_user_input.begin(),
+                                                     forbidden_ranges_user_input.end(), ::isspace),
+                                      forbidden_ranges_user_input.end());
+
+    std::vector<std::string> forbidden_ranges_strings;
+    boost::split(forbidden_ranges_strings, forbidden_ranges_user_input, boost::is_any_of(","));
+
+    // Parse input (check string regex and convert to numeric)
+    auto numeric_range_regex = std::regex("^(\\d+)-(\\d+)$");
+    for (const auto &elem : forbidden_ranges_strings) {
+        std::smatch regex_match;
+        if (!std::regex_match(elem, regex_match, numeric_range_regex)) {
+            std::cout << "Range element " << elem << " does not match int-int format" << std::endl;
+            // return speed;
+            return; // TODO
+        }
+
+        constexpr size_t LOWER_BOUND_MATCH_INDEX = 1;
+        constexpr size_t UPPER_BOUND_MATCH_INDEX = 2;
+        auto             lower_bound             = std::stoi(regex_match[LOWER_BOUND_MATCH_INDEX]);
+        auto             higher_bound            = std::stoi(regex_match[UPPER_BOUND_MATCH_INDEX]);
+        if (lower_bound >= higher_bound) {
+            std::cout << "Invalid range: " << elem << ". Upper bound must be greater than lower bound." << std::endl;
+            return; // TODO
+        }
+        forbidden_ranges.emplace_back(lower_bound, higher_bound);
+    }
+
+    // Check range consistency (Simply check for overlap. User can enter them in non-ascending lower bound order)
+
+    std::sort(forbidden_ranges.begin(), forbidden_ranges.end(),
+              [](auto &left, auto &right) { return left.first < right.first; });
+
+    for (size_t i = 1; i < forbidden_ranges.size(); i++) {
+        int range_start_front = forbidden_ranges[i].first;
+        int range_end_back    = forbidden_ranges[i - 1].second;
+        if (range_start_front < range_end_back) {
+            return; // TODO
+        }
+    }
+}
+
+
+double_t ExcludePrintSpeeds::adjust_speed_if_in_forbidden_range(double speed)
+{
+    for (auto range : forbidden_ranges) {
+        if (speed > range.first && speed < range.second) {
+            speed = (move_to_lowest_allowed_speed) ? range.first : range.second;
+            return speed;
+        }
+    }
+
+    return speed;
+}
+
+}

--- a/src/libslic3r/GCode/ExcludePrintSpeeds.hpp
+++ b/src/libslic3r/GCode/ExcludePrintSpeeds.hpp
@@ -16,13 +16,10 @@ static constexpr size_t UPPER_BOUND_MATCH_INDEX = 2;
     std::vector<std::pair<int, int>> forbidden_ranges;
     bool move_to_lowest_allowed_speed{true};
 
-
-
 public:
-    ExcludePrintSpeeds(const std::string& _forbidden_ranges_user_input, bool _move_to_lowest_available_range);
+    ExcludePrintSpeeds(const std::string &_forbidden_ranges_user_input, bool _move_to_lowest_available_range);
 
     double_t adjust_speed_if_in_forbidden_range(double speed);
-
 };
 
 }

--- a/src/libslic3r/GCode/ExcludePrintSpeeds.hpp
+++ b/src/libslic3r/GCode/ExcludePrintSpeeds.hpp
@@ -13,8 +13,12 @@ private:
 static constexpr size_t LOWER_BOUND_MATCH_INDEX = 1;
 static constexpr size_t UPPER_BOUND_MATCH_INDEX = 2;
 
-    std::vector<std::pair<int, int>> forbidden_ranges;
+    std::vector<std::pair<int, int>> excluded_ranges;
     ConfigOptionEnum<ExcludePrintSpeedsAdjustmentDirection> adjustment_direction;
+
+    static std::vector<std::string> split_user_input_ranges_to_individual_strings(const std::string &_excluded_ranges_user_input);
+    void parse_input(std::vector<std::string> excluded_ranges_strings);
+    void check_input_correctness(const std::vector<std::string> &excluded_ranges_strings);
 
 public:
     ExcludePrintSpeeds(const std::string &_forbidden_ranges_user_input,

--- a/src/libslic3r/GCode/ExcludePrintSpeeds.hpp
+++ b/src/libslic3r/GCode/ExcludePrintSpeeds.hpp
@@ -1,0 +1,30 @@
+#ifndef slic3r_ExcludePrintSpeeds_hpp_
+#define slic3r_ExcludePrintSpeeds_hpp_
+
+#include "../libslic3r.h"
+
+#include <cmath>
+
+namespace Slic3r {
+
+class ExcludePrintSpeeds
+{
+private:
+static constexpr size_t LOWER_BOUND_MATCH_INDEX = 1;
+static constexpr size_t UPPER_BOUND_MATCH_INDEX = 2;
+
+    std::vector<std::pair<int, int>> forbidden_ranges;
+    bool move_to_lowest_allowed_speed{true};
+
+
+
+public:
+    ExcludePrintSpeeds(const std::string& _forbidden_ranges_user_input, bool _move_to_lowest_available_range);
+
+    double_t adjust_speed_if_in_forbidden_range(double speed);
+
+};
+
+}
+
+#endif // slic3r_ExcludePrintSpeeds_hpp_

--- a/src/libslic3r/GCode/ExcludePrintSpeeds.hpp
+++ b/src/libslic3r/GCode/ExcludePrintSpeeds.hpp
@@ -1,7 +1,7 @@
 #ifndef slic3r_ExcludePrintSpeeds_hpp_
 #define slic3r_ExcludePrintSpeeds_hpp_
 
-#include "../libslic3r.h"
+#include "../Print.hpp"
 
 #include <cmath>
 
@@ -14,10 +14,11 @@ static constexpr size_t LOWER_BOUND_MATCH_INDEX = 1;
 static constexpr size_t UPPER_BOUND_MATCH_INDEX = 2;
 
     std::vector<std::pair<int, int>> forbidden_ranges;
-    bool move_to_lowest_allowed_speed{true};
+    ConfigOptionEnum<ExcludePrintSpeedsAdjustmentDirection> adjustment_direction;
 
 public:
-    ExcludePrintSpeeds(const std::string &_forbidden_ranges_user_input, bool _move_to_lowest_available_range);
+    ExcludePrintSpeeds(const std::string &_forbidden_ranges_user_input,
+                       const ConfigOptionEnum<ExcludePrintSpeedsAdjustmentDirection> &_adjustment_direction);
 
     double_t adjust_speed_if_in_forbidden_range(double speed);
 };

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -544,6 +544,7 @@ static std::vector<std::string> s_Preset_print_options {
         "max_volumetric_speed",
         "exclude_print_speed_low",
         "exclude_print_speed_high",
+        "exclude_print_speed_move_to_lowest_available_range",
         // gapfill
         "gap_fill_enabled",
         "gap_fill_extension",

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -542,6 +542,8 @@ static std::vector<std::string> s_Preset_print_options {
         "travel_speed", "travel_speed_z",
         "max_print_speed",
         "max_volumetric_speed",
+        "exclude_print_speed_low",
+        "exclude_print_speed_high",
         // gapfill
         "gap_fill_enabled",
         "gap_fill_extension",

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -542,8 +542,7 @@ static std::vector<std::string> s_Preset_print_options {
         "travel_speed", "travel_speed_z",
         "max_print_speed",
         "max_volumetric_speed",
-        "exclude_print_speed_low",
-        "exclude_print_speed_high",
+        "exclude_print_speed_ranges",
         "exclude_print_speed_move_to_lowest_available_range",
         // gapfill
         "gap_fill_enabled",

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -543,7 +543,7 @@ static std::vector<std::string> s_Preset_print_options {
         "max_print_speed",
         "max_volumetric_speed",
         "exclude_print_speed_ranges",
-        "exclude_print_speed_move_to_lowest_available_range",
+        "exclude_print_speed_adjustment_direction",
         // gapfill
         "gap_fill_enabled",
         "gap_fill_extension",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1952,8 +1952,11 @@ void PrintConfigDef::init_fff_params()
     //   other features.
     def = this->add("exclude_print_speed_ranges", coString);
     def->label = L("Excluded speed ranges (in mm/s)");
-    def->tooltip = L("Speed ranges to be excluded. One use case is to avoid CoreXY kinematic resonances. "
-                     "Leave empty to disable");
+    def->tooltip = L("Speed ranges to be excluded. If any speeds fall in these ranges, they will be raised/lowered "
+                     "based on the adjustment direction. In its current state, only speeds set by the user in the speed "
+                     "section will be affected, not speeds set by the minimum layer time. One use case for this feature"
+                     " is to avoid CoreXY kinematic resonances. "
+                     "Leave empty to disable.");
     def->mode = comExpert | comPrusa;
     // def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionString{""});

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1960,7 +1960,15 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->mode = comAdvancedE | comPrusa;
     // def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionFloat{ 0. });
+    def->set_default_value(new ConfigOptionFloat{0.});
+
+    def             = this->add("exclude_print_speed_move_to_lowest_available_range", coBool);
+    def->label      = L("Adjust speed to lowest range");
+    def->category   = OptionCategory::speed;
+    def->tooltip    = L("If set to true, the speed is dropped to the lowest value of the forbidden range."
+                        "Otherwise, the highest value of the range is chosen.");
+    def->mode       = comAdvancedE | comSuSi;
+    def->set_default_value(new ConfigOptionBool(true));
 
     def = this->add("filament_max_wipe_tower_speed", coFloats);
     def->label = L("Max speed on the wipe tower");
@@ -8118,7 +8126,8 @@ std::unordered_set<std::string> prusa_export_to_remove_keys = {
 "enforce_full_fill_volume",
 // "exact_last_layer_height",
 "exclude_print_speed_low"
-"exclude_print_speed_high"
+"exclude_print_speed_high",
+"exclude_print_speed_move_to_lowest_available_range",
 "external_infill_margin",
 "external_perimeter_acceleration",
 "external_perimeter_cut_corners",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1959,7 +1959,7 @@ void PrintConfigDef::init_fff_params()
         " is to avoid CoreXY kinematic resonances. In its current state, only speeds set by the user in the speed "
         "section will be affected, not speeds set by the minimum layer time. "
         "\nLeave empty to disable.");
-    def->mode = comExpert | comPrusa;
+    def->mode = comExpert | comSuSi;
     // def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionString{""});
 
@@ -1981,7 +1981,7 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.emplace_back(L("Lowest"));
     def->enum_labels.emplace_back(L("Highest"));
     def->enum_labels.emplace_back(L("Nearest"));
-    def->mode = comAdvancedE | comSuSi;
+    def->mode = comExpert | comSuSi;
     def->set_default_value(new ConfigOptionEnum<ExcludePrintSpeedsAdjustmentDirection>(epsdLowest));
 
     def = this->add("filament_max_wipe_tower_speed", coFloats);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1958,7 +1958,7 @@ void PrintConfigDef::init_fff_params()
         "according to the adjustment direction. One use case for this feature"
         " is to avoid CoreXY kinematic resonances. In its current state, only speeds set by the user in the speed "
         "section will be affected, not speeds set by the minimum layer time. "
-        "Leave empty to disable.");
+        "\nLeave empty to disable.");
     def->mode = comExpert | comPrusa;
     // def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionString{""});

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1952,11 +1952,13 @@ void PrintConfigDef::init_fff_params()
     //   other features.
     def = this->add("exclude_print_speed_ranges", coString);
     def->label = L("Excluded speed ranges (in mm/s)");
-    def->tooltip = L("Speed ranges to be excluded. If any speeds fall in these ranges, they will be raised/lowered "
-                     "based on the adjustment direction. In its current state, only speeds set by the user in the speed "
-                     "section will be affected, not speeds set by the minimum layer time. One use case for this feature"
-                     " is to avoid CoreXY kinematic resonances. "
-                     "Leave empty to disable.");
+    def->tooltip = L(
+        "Speed ranges to be excluded. Example input form: 30-40, 60-80. "
+        "If any speeds fall in these ranges, they will be raised/lowered "
+        "according to the adjustment direction. One use case for this feature"
+        " is to avoid CoreXY kinematic resonances. In its current state, only speeds set by the user in the speed "
+        "section will be affected, not speeds set by the minimum layer time. "
+        "Leave empty to disable.");
     def->mode = comExpert | comPrusa;
     // def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionString{""});

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1941,26 +1941,15 @@ void PrintConfigDef::init_fff_params()
     def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionFloats{ 0. });
 
-    // TODO - chka: Show better feature description on mouse hover (also show "set to 0 to disable")
-    def = this->add("exclude_print_speed_low", coFloat);
-    def->label = L("Lower bound");
-    def->category = OptionCategory::speed;
-    def->tooltip = L("Start of excluded speed range");
-    def->sidetext = L("mm/s");
-    def->min = 0;
-    def->mode = comAdvancedE | comPrusa;
+    // TODO - chka: Show better feature description on mouse hover. Describe use cases and interaction with
+    //   other features.
+    def = this->add("exclude_print_speed_ranges", coString);
+    def->label = L("Excluded speed ranges (in mm/s)");
+    def->tooltip = L("Speed ranges to be excluded. One use case is to avoid CoreXY kinematic resonances. "
+                     "Leave empty to disable");
+    def->mode = comExpert | comPrusa;
     // def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionFloat{ 0. });
-
-    def = this->add("exclude_print_speed_high", coFloat);
-    def->label = L("Higher bound");
-    def->category = OptionCategory::speed;
-    def->tooltip = L("End of excluded speed range");
-    def->sidetext = L("mm/s");
-    def->min = 0;
-    def->mode = comAdvancedE | comPrusa;
-    // def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionFloat{0.});
+    def->set_default_value(new ConfigOptionString{""});
 
     def             = this->add("exclude_print_speed_move_to_lowest_available_range", coBool);
     def->label      = L("Adjust speed to lowest range");
@@ -8125,8 +8114,7 @@ std::unordered_set<std::string> prusa_export_to_remove_keys = {
 "default_speed",
 "enforce_full_fill_volume",
 // "exact_last_layer_height",
-"exclude_print_speed_low"
-"exclude_print_speed_high",
+"exclude_print_speed_ranges"
 "exclude_print_speed_move_to_lowest_available_range",
 "external_infill_margin",
 "external_perimeter_acceleration",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1941,6 +1941,27 @@ void PrintConfigDef::init_fff_params()
     def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionFloats{ 0. });
 
+    // TODO - chka: Show better feature description on mouse hover (also show "set to 0 to disable")
+    def = this->add("exclude_print_speed_low", coFloat);
+    def->label = L("Lower bound");
+    def->category = OptionCategory::speed;
+    def->tooltip = L("Start of excluded speed range");
+    def->sidetext = L("mm/s");
+    def->min = 0;
+    def->mode = comAdvancedE | comPrusa;
+    // def->is_vector_extruder = true;
+    def->set_default_value(new ConfigOptionFloat{ 0. });
+
+    def = this->add("exclude_print_speed_high", coFloat);
+    def->label = L("Higher bound");
+    def->category = OptionCategory::speed;
+    def->tooltip = L("End of excluded speed range");
+    def->sidetext = L("mm/s");
+    def->min = 0;
+    def->mode = comAdvancedE | comPrusa;
+    // def->is_vector_extruder = true;
+    def->set_default_value(new ConfigOptionFloat{ 0. });
+
     def = this->add("filament_max_wipe_tower_speed", coFloats);
     def->label = L("Max speed on the wipe tower");
     def->tooltip = L("This setting is used to set the maximum speed when extruding inside the wipe tower (use M220)."
@@ -8096,6 +8117,8 @@ std::unordered_set<std::string> prusa_export_to_remove_keys = {
 "default_speed",
 "enforce_full_fill_volume",
 // "exact_last_layer_height",
+"exclude_print_speed_low"
+"exclude_print_speed_high"
 "external_infill_margin",
 "external_perimeter_acceleration",
 "external_perimeter_cut_corners",

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1287,8 +1287,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloats,               wiping_volumes_extruders))
     ((ConfigOptionFloat,                z_offset))
     ((ConfigOptionFloat,                init_z_rotate))
-    ((ConfigOptionFloat,                exclude_print_speed_low))
-    ((ConfigOptionFloat,                exclude_print_speed_high))
+    ((ConfigOptionString,               exclude_print_speed_ranges))
     ((ConfigOptionBool,                 exclude_print_speed_move_to_lowest_available_range))
 
 )

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1287,6 +1287,8 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloats,               wiping_volumes_extruders))
     ((ConfigOptionFloat,                z_offset))
     ((ConfigOptionFloat,                init_z_rotate))
+    ((ConfigOptionFloat,                exclude_print_speed_low))
+    ((ConfigOptionFloat,                exclude_print_speed_high))
 
 )
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -193,6 +193,11 @@ enum InfillConnection {
     icConnected, icHoles, icOuterShell, icNotConnected,
 };
 
+enum ExcludePrintSpeedsAdjustmentDirection
+{
+    epsdLowest, epsdHighest, epsdNearest
+};
+
 enum RemainingTimeType : uint8_t{
     rtNone      = 0,
     rtM117      = 1<<0,
@@ -300,6 +305,7 @@ CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(DraftShield)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(GCodeThumbnailsFormat)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(ZLiftTop)
 CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(PerimeterGeneratorType)
+CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS(ExcludePrintSpeedsAdjustmentDirection)
 
 #undef CONFIG_OPTION_ENUM_DECLARE_STATIC_MAPS
 
@@ -1288,7 +1294,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloat,                z_offset))
     ((ConfigOptionFloat,                init_z_rotate))
     ((ConfigOptionString,               exclude_print_speed_ranges))
-    ((ConfigOptionBool,                 exclude_print_speed_move_to_lowest_available_range))
+    ((ConfigOptionEnum<ExcludePrintSpeedsAdjustmentDirection>,  exclude_print_speed_adjustment_direction))
 
 )
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1289,6 +1289,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloat,                init_z_rotate))
     ((ConfigOptionFloat,                exclude_print_speed_low))
     ((ConfigOptionFloat,                exclude_print_speed_high))
+    ((ConfigOptionBool,                 exclude_print_speed_move_to_lowest_available_range))
 
 )
 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -340,7 +340,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
         "external_perimeters_first", "external_perimeter_extrusion_width", "external_perimeter_extrusion_spacing","external_perimeter_extrusion_change_odd_layers",
         "overhangs", "perimeter_speed", "perimeter_reverse",
         "seam_position", "small_perimeter_speed", "small_perimeter_min_length", " small_perimeter_max_length", "spiral_vase",
-        "perimeter_generator", "seam_notch_all", "seam_notch_inner", "seam_notch_outer"})
+        "perimeter_generator", "seam_notch_all", "seam_notch_inner", "seam_notch_outer", "exclude_print_speed_low", "exclude_print_speed_high"})
         toggle_field(el, have_perimeters);
 
     bool has_spiral_vase = have_perimeters && config->opt_bool("spiral_vase");

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -341,7 +341,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
         "overhangs", "perimeter_speed", "perimeter_reverse",
         "seam_position", "small_perimeter_speed", "small_perimeter_min_length", " small_perimeter_max_length", "spiral_vase",
         "perimeter_generator", "seam_notch_all", "seam_notch_inner", "seam_notch_outer",
-        "exclude_print_speed_ranges", "exclude_print_speed_move_to_lowest_available_range"})
+        "exclude_print_speed_ranges", "exclude_print_speed_adjustment_direction"})
         toggle_field(el, have_perimeters);
 
     bool has_spiral_vase = have_perimeters && config->opt_bool("spiral_vase");

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -340,7 +340,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
         "external_perimeters_first", "external_perimeter_extrusion_width", "external_perimeter_extrusion_spacing","external_perimeter_extrusion_change_odd_layers",
         "overhangs", "perimeter_speed", "perimeter_reverse",
         "seam_position", "small_perimeter_speed", "small_perimeter_min_length", " small_perimeter_max_length", "spiral_vase",
-        "perimeter_generator", "seam_notch_all", "seam_notch_inner", "seam_notch_outer", "exclude_print_speed_low", "exclude_print_speed_high"})
+        "perimeter_generator", "seam_notch_all", "seam_notch_inner", "seam_notch_outer",
+        "exclude_print_speed_low", "exclude_print_speed_high", "exclude_print_speed_move_to_lowest_available_range"})
         toggle_field(el, have_perimeters);
 
     bool has_spiral_vase = have_perimeters && config->opt_bool("spiral_vase");

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -341,7 +341,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
         "overhangs", "perimeter_speed", "perimeter_reverse",
         "seam_position", "small_perimeter_speed", "small_perimeter_min_length", " small_perimeter_max_length", "spiral_vase",
         "perimeter_generator", "seam_notch_all", "seam_notch_inner", "seam_notch_outer",
-        "exclude_print_speed_low", "exclude_print_speed_high", "exclude_print_speed_move_to_lowest_available_range"})
+        "exclude_print_speed_ranges", "exclude_print_speed_move_to_lowest_available_range"})
         toggle_field(el, have_perimeters);
 
     bool has_spiral_vase = have_perimeters && config->opt_bool("spiral_vase");


### PR DESCRIPTION
Hello, fellow 3D printing people

I have implemented the first version of the feature requested in #4105. This version allows the slicer to detect speeds for external perimeters and overhang perimeters which fall into user specified excluded speed ranges, and adjust them according to one of the following options in the dropdown menu:

- Lowest:  drop the speed to the lowest value of the range.
- Highest: raise the speed to the highest value of the range.
- Nearest: change the speed to whichever value of the above is closest to the speed set.

Since this is the first version, the only speeds checked are the ones entered by the user in the "speed" section. Those are
- Speeds that are set explicitly in the form of mm/s
- Speeds that are set implicitly, as a percentage of another speed.

The minimum layer time feature is applied _after_ this feature takes place, and still works as it should. The next version of this feature will work alongside the minimum layer time. I am working on another project in parallel and have really under-powered equipment at the moment, so I would need about a week to start working on the next version. 
Now that the GUI and backend frameworks are in place, the changes would be minimal for the next version. I mostly know what needs to be done already. I hope the code is clean enough, I also made the initialization only run once per slice to avoid parsing the input all the time.

![Screenshot from 2024-07-18 19-54-55](https://github.com/user-attachments/assets/745c0c9e-d2e4-4e9f-8b7e-18dcd91ea42d)

An open question for the readers since I cannot print at the moment:
- If we have "bad" speeds for the internal perimeters but "good" ones for the outer ones, do the artifacts come to the surface? Changing where this feature takes place is a matter of one line so do let me know and I can change it.

The user can enter as many ranges as they wish, and the order of said ranges matters not. The ranges' format is checked, as well as their correctness. The second bound must be higher than the first bound, and the ranges must not overlap. An error is displayed on each case, with an example shown below.

![Screenshot from 2024-07-18 11-31-06](https://github.com/user-attachments/assets/801712ea-4ec9-4583-850a-444a05d358f6)

My apologies in advance if anything is out of place, my current equipment is too dodgy to allow me to get any more work done at the moment.