### PR TITLE
Fix small area infill flow compensation (graph version) causing some lines to not extrude (#4374)

### DIFF
--- a/resources/ui_layout/Readme.md
+++ b/resources/ui_layout/Readme.md
@@ -206,8 +206,10 @@ These functions can only be called in a `set` or `reset` function. If you need t
 ### others
   * void **ask_for_refresh**()
     ask for a OPTNAME_set() after the current OPTNAME_get(), to be able to set settings.
-  * bool **is_enabled**(string setting_key)
-    Experimental. Ask if this setting is currently enabled. Dangerous, as it will be true if it's not constructed. 
+  * bool **is_enabled**(string setting_key, int idx)
+    Ask if this setting is currently enabled. `idx` is the index of the value if the settigns is a vector, it's ignored if it's a scalar.
+  * bool **is_widget_enabled**(string setting_key)
+    Experimental. Ask if a widget for this setting is currently enabled. Dangerous, as it will be true if it's not constructed. 
 
 ### to get/set the value of a custom variable
 The first argument is the index of the tab setting: 0 for print settings, 1 for filament settings and 2 for printer settings.

--- a/resources/ui_layout/default/filament.ui
+++ b/resources/ui_layout/default/filament.ui
@@ -11,13 +11,13 @@ group:Temperature °C
 	line:Extruder
 		setting:id$0:first_layer_temperature
 		setting:id$0:temperature
-		setting:id$0:label$Idle:idle_temperature
 	end_line
 	line:Bed
 		setting:id$0:first_layer_bed_temperature
 		setting:id$0:label$Other layers:bed_temperature
 	end_line
 	setting:id$0:chamber_temperature
+    setting:id$0:label$Idle:idle_temperature
 group:Filament properties
 	setting:id$0:width$7:filament_type
 	setting:id$0:filament_soluble

--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -2,7 +2,7 @@
 page:Perimeters & Shell:shell
 group:Vertical shells
 	line:Perimeters
-		setting:label$Contour:width$6:perimeters
+		setting:label$Contour:width$6:sidetext_width$10:perimeters
         setting:label$Holes:width$6:perimeters_hole
 	end_line
 	setting:tags$Simple$Expert$SuSi:script:float:depends$perimeter_spacing$external_perimeter_spacing:label$Wall Thickness:tooltip$Change the perimeter extrusion widths to ensure that there is an exact number of perimeters for this wall thickness value. It won't put the perimeter width below the nozzle diameter, and up to double.\nNote that the value displayed is just a view of the current perimeter thickness, like the info text below. The number of perimeters used to compute this value is one loop, or the custom variable 'wall_thickness_lines' (advanced mode) if defined.\nIf the value is too low, it will revert the widths to the saved value.\nIf the value is set to 0, it will show 0.:s_wall_thickness

--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -358,26 +358,24 @@ size_t GraphData::data_size() const
 }
 
 double GraphData::interpolate(double x_value) const{
-    double y_value = 0.;
+    double y_value = 1.0f;
     if (this->data_size() < 1) {
         // nothing
-    } else if (this->graph_points.size() == 1 || this->graph_points.front().x() >= x_value) {
+    } else if (this->graph_points.size() == 1 || this->graph_points[begin_idx].x() >= x_value) {
         y_value = this->graph_points.front().y();
-    } else if (this->graph_points.back().x() <= x_value) {
+    } else if (this->graph_points[end_idx - 1].x() <= x_value) {
         y_value = this->graph_points.back().y();
     } else {
         // find first and second datapoint
         for (size_t idx = this->begin_idx; idx < this->end_idx; ++idx) {
             const auto &data_point = this->graph_points[idx];
-            if (data_point.x() == x_value) {
+            if (is_approx(data_point.x(), x_value)) {
                 // lucky point
-                y_value = data_point.y();
-                break;
+                return data_point.y();
             } else if (data_point.x() < x_value) {
                 // not yet, iterate
             } else if (idx == 0) {
-                y_value = data_point.y();
-                break;
+                return data_point.y();
             } else {
                 // interpolate
                 const auto &data_point_before = this->graph_points[idx - 1];
@@ -453,7 +451,7 @@ double GraphData::interpolate(double x_value) const{
                 } else {
                     assert(false);
                 }
-                break;
+                return y_value;
             }
         }
     }

--- a/src/libslic3r/Config.cpp
+++ b/src/libslic3r/Config.cpp
@@ -138,8 +138,10 @@ std::string escape_strings_cstyle(const std::vector<std::string> &strs, const st
         if (j > 0)
             // Separate the strings.
             (*outptr ++) = ';';
-        if (!(enables.empty() || enables[j]))
-            (*outptr ++) = '!';
+        if (!(enables.empty() || enables[j])) {
+            (*outptr++) = '!';
+            (*outptr++) = ':';
+        }
         const std::string &str = strs[j];
         // Is the string simple or complex? Complex string contains spaces, tabs, new lines and other
         // escapable characters. Empty string shall be quoted as well, if it is the only string in strs.
@@ -220,8 +222,9 @@ bool unescape_strings_cstyle(const std::string &str, std::vector<std::string> &o
             c = str[i];
         }
         bool enable = true;
-        if (c == '!') {
+        if (c == '!' && str.size() > i + 1 && str[i + 1] == ':') {
             enable = false;
+            ++i;
             c = str[++i];
         }
         // Start of a word.
@@ -629,41 +632,43 @@ std::vector<std::string> ConfigOptionDef::cli_args(const std::string &key) const
 
 ConfigOption* ConfigOptionDef::create_empty_option() const
 {
-	if (this->nullable) {
-	    switch (this->type) {
-        case coFloat:           return new ConfigOptionFloatNullable();
-        case coInt:             return new ConfigOptionIntNullable();
-	    case coFloats:          return new ConfigOptionFloatsNullable();
-	    case coInts:            return new ConfigOptionIntsNullable();
-	    case coPercents:        return new ConfigOptionPercentsNullable();
-        case coFloatsOrPercents: return new ConfigOptionFloatsOrPercentsNullable();
-	    case coBools:           return new ConfigOptionBoolsNullable();
-	    default:                throw ConfigurationError(std::string("Unknown option type for nullable option ") + this->label);
-	    }
-	} else {
-	    switch (this->type) {
-	    case coFloat:           return new ConfigOptionFloat();
-	    case coFloats:          return new ConfigOptionFloats();
-	    case coInt:             return new ConfigOptionInt();
-	    case coInts:            return new ConfigOptionInts();
-	    case coString:          return new ConfigOptionString();
-	    case coStrings:         return new ConfigOptionStrings();
-	    case coPercent:         return new ConfigOptionPercent();
-	    case coPercents:        return new ConfigOptionPercents();
-	    case coFloatOrPercent:  return new ConfigOptionFloatOrPercent();
-        case coFloatsOrPercents: return new ConfigOptionFloatsOrPercents();
-	    case coPoint:           return new ConfigOptionPoint();
-	    case coPoints:          return new ConfigOptionPoints();
-	    case coPoint3:          return new ConfigOptionPoint3();
-	//    case coPoint3s:         return new ConfigOptionPoint3s();
-	    case coGraph:           return new ConfigOptionGraph();
-	    case coGraphs:          return new ConfigOptionGraphs();
-	    case coBool:            return new ConfigOptionBool();
-	    case coBools:           return new ConfigOptionBools();
-	    case coEnum:            return new ConfigOptionEnumGeneric(this->enum_def->m_enum_keys_map);
-	    default:                throw ConfigurationError(std::string("Unknown option type for option ") + this->label);
-	    }
+    ConfigOption* opt = nullptr;
+    ConfigOptionVectorBase* opt_vec = nullptr;
+	switch (this->type) {
+	case coFloat:            opt = new ConfigOptionFloat(); break;
+	case coFloats:           opt = opt_vec = new ConfigOptionFloats(); break;
+	case coInt:              opt = new ConfigOptionInt(); break;
+	case coInts:             opt = opt_vec = new ConfigOptionInts(); break;
+	case coString:           opt = new ConfigOptionString(); break;
+	case coStrings:          opt = opt_vec = new ConfigOptionStrings(); break;
+	case coPercent:          opt = new ConfigOptionPercent(); break;
+	case coPercents:         opt = opt_vec = new ConfigOptionPercents(); break;
+	case coFloatOrPercent:   opt = new ConfigOptionFloatOrPercent(); break;
+    case coFloatsOrPercents: opt = opt_vec = new ConfigOptionFloatsOrPercents(); break;
+	case coPoint:            opt = new ConfigOptionPoint(); break;
+	case coPoints:           opt = opt_vec = new ConfigOptionPoints(); break;
+	case coPoint3:           opt = new ConfigOptionPoint3(); break;
+//    case coPoint3s:         return new ConfigOptionPoint3s();
+	case coGraph:            opt = new ConfigOptionGraph(); break;
+	case coGraphs:           opt = opt_vec = new ConfigOptionGraphs(); break;
+	case coBool:             opt = new ConfigOptionBool(); break;
+	case coBools:            opt = opt_vec = new ConfigOptionBools(); break;
+	case coEnum:             opt = new ConfigOptionEnumGeneric(this->enum_def->m_enum_keys_map); break;
+	default:                throw ConfigurationError(std::string("Unknown option type for option ") + this->label);
 	}
+    if (this->is_vector_extruder) {
+        assert(opt_vec);
+        opt_vec->set_is_extruder_size(true);
+    }
+    if (this->can_be_disabled) {
+        assert(opt);
+        opt->set_can_be_disabled();
+        opt->set_enabled(false);
+    }
+    if (this->can_phony) {
+        opt->set_phony(true);
+    }
+    return opt;
 }
 
 ConfigOption* ConfigOptionDef::create_default_option() const
@@ -676,6 +681,21 @@ ConfigOption* ConfigOptionDef::create_default_option() const
     return this->create_empty_option();
 }
 
+void ConfigOptionDef::set_default_value(ConfigOption *ptr) {
+    assert(!ptr->is_vector());
+    if (this->can_be_disabled) {
+        ptr->set_can_be_disabled();
+    }
+    this->default_value = Slic3r::clonable_ptr<const ConfigOption>(ptr);
+}
+void ConfigOptionDef::set_default_value(ConfigOptionVectorBase *ptr) {
+    ptr->set_is_extruder_size(this->is_vector_extruder);
+    if (this->can_be_disabled) {
+        ptr->set_can_be_disabled();
+    }
+    this->default_value = Slic3r::clonable_ptr<const ConfigOption>(ptr);
+}
+
 // Assignment of the serialization IDs is not thread safe. The Defs shall be initialized from the main thread!
 ConfigOptionDef* ConfigDef::add(const t_config_option_key &opt_key, ConfigOptionType type)
 {
@@ -686,13 +706,6 @@ ConfigOptionDef* ConfigDef::add(const t_config_option_key &opt_key, ConfigOption
     opt->serialization_key_ordinal = ++ serialization_key_ordinal_last;
     this->by_serialization_key_ordinal[opt->serialization_key_ordinal] = opt;
     return opt;
-}
-
-ConfigOptionDef* ConfigDef::add_nullable(const t_config_option_key &opt_key, ConfigOptionType type)
-{
-	ConfigOptionDef *def = this->add(opt_key, type);
-	def->nullable = true;
-	return def;
 }
 
 void ConfigDef::finalize()
@@ -1298,7 +1311,6 @@ bool ConfigBase::set_deserialize_raw(const t_config_option_key &opt_key_src, con
         bool substituted = false;
         if (optdef->type == coBools && substitutions_ctxt.rule != ForwardCompatibilitySubstitutionRule::Disable) {
             //FIXME Special handling of vectors of bools, quick and not so dirty solution before PrusaSlicer 2.3.2 release.
-            bool nullable = opt->nullable();
             ConfigHelpers::DeserializationSubstitution default_value = ConfigHelpers::DeserializationSubstitution::DefaultsToFalse;
             if (optdef->default_value) {
                 // Default value for vectors of booleans used in a "per extruder" context, thus the default contains just a single value.
@@ -1307,9 +1319,7 @@ bool ConfigBase::set_deserialize_raw(const t_config_option_key &opt_key_src, con
                 if (values.size() == 1 && values.front() == 1)
                     default_value = ConfigHelpers::DeserializationSubstitution::DefaultsToTrue;
             }
-            auto result = nullable ?
-                static_cast<ConfigOptionBoolsNullable*>(opt)->deserialize_with_substitutions(value, append, default_value) :
-                static_cast<ConfigOptionBools*>(opt)->deserialize_with_substitutions(value, append, default_value);
+            auto result = static_cast<ConfigOptionBools*>(opt)->deserialize_with_substitutions(value, append, default_value);
             success     = result != ConfigHelpers::DeserializationResult::Failed;
             substituted = result == ConfigHelpers::DeserializationResult::Substituted;
         } else {
@@ -1347,9 +1357,15 @@ bool ConfigBase::set_deserialize_raw(const t_config_option_key &opt_key_src, con
             opt->set_phony(false);
     else
         opt->set_phony(false);
+    
+    if (optdef->is_vector_extruder) {
+        assert(dynamic_cast<ConfigOptionVectorBase *>(opt));
+        static_cast<ConfigOptionVectorBase *>(opt)->set_is_extruder_size(true);
+    }
 
-    if (optdef->is_vector_extruder)
-        static_cast<ConfigOptionVectorBase*>(opt)->set_is_extruder_size(true);
+    if (optdef->can_be_disabled)
+        opt->set_can_be_disabled();
+
     return success;
 }
 
@@ -2004,14 +2020,18 @@ void ConfigBase::save(const std::string &file, bool to_prusa) const
     c.close();
 }
 
-// Set all the nullable values to nils.
-void ConfigBase::null_nullables()
+// Disable all the optional settings.
+void ConfigBase::disable_optionals()
 {
     for (const std::string &opt_key : this->keys()) {
         ConfigOption *opt = this->optptr(opt_key, false);
-        assert(opt != nullptr);
-        if (opt->nullable())
-        	opt->deserialize("nil", ForwardCompatibilitySubstitutionRule::Disable);
+        const ConfigOptionDef* def = get_option_def(opt_key);
+        assert(opt != nullptr && def != nullptr);
+        if (opt && def && def->is_optional) {
+            assert(def->can_be_disabled);
+            assert(opt->can_be_disabled());
+            opt->set_enabled(false);
+        }
     }
 }
 
@@ -2035,11 +2055,12 @@ bool DynamicConfig::operator==(const DynamicConfig &rhs) const
 }
 
 // Remove options with all nil values, those are optional and it does not help to hold them.
-size_t DynamicConfig::remove_nil_options()
+size_t DynamicConfig::remove_optional_disabled_options()
 {
+    assert(false); // TODO: add check for optional 
 	size_t cnt_removed = 0;
 	for (auto it = options.begin(); it != options.end();)
-		if (it->second->is_nil()) {
+		if (!it->second->is_enabled()) {
 			it = options.erase(it);
 			++ cnt_removed;
 		} else
@@ -2321,9 +2342,6 @@ CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionSingle<std::string>)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionSingle<Slic3r::Vec2d>)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionSingle<Slic3r::Vec3d>)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionSingle<bool>)
-CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionSingleNullable<double>)
-CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionSingleNullable<int>)
-CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionSingleNullable<bool>)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionVectorBase)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionVector<double>)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionVector<int32_t>)
@@ -2331,21 +2349,15 @@ CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionVector<std::string>)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionVector<Slic3r::Vec2d>)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionVector<unsigned char>)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionFloat)
-CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionFloatNullable)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionFloats)
-CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionFloatsNullable)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionInt)
-CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionIntNullable)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionInts)
-CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionIntsNullable)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionString)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionStrings)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionPercent)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionPercents)
-CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionPercentsNullable)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionFloatOrPercent)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionFloatsOrPercents)
-CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionFloatsOrPercentsNullable)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionPoint)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionPoints)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionPoint3)
@@ -2353,7 +2365,6 @@ CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionGraph)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionGraphs)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionBool)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionBools)
-CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionBoolsNullable)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigOptionEnumGeneric)
 CEREAL_REGISTER_TYPE(Slic3r::ConfigBase)
 CEREAL_REGISTER_TYPE(Slic3r::DynamicConfig)
@@ -2365,9 +2376,6 @@ CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOption, Slic3r::ConfigOptionS
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOption, Slic3r::ConfigOptionSingle<Slic3r::Vec3d>)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOption, Slic3r::ConfigOptionSingle<Slic3r::GraphData>)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOption, Slic3r::ConfigOptionSingle<bool>) 
-CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOption, Slic3r::ConfigOptionSingleNullable<double>)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOption, Slic3r::ConfigOptionSingleNullable<int>)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOption, Slic3r::ConfigOptionSingleNullable<bool>)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOption, Slic3r::ConfigOptionVectorBase) 
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVectorBase, Slic3r::ConfigOptionVector<double>)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVectorBase, Slic3r::ConfigOptionVector<int32_t>)
@@ -2376,21 +2384,15 @@ CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVectorBase, Slic3r::Con
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVectorBase, Slic3r::ConfigOptionVector<Slic3r::GraphData>)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVectorBase, Slic3r::ConfigOptionVector<unsigned char>)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionSingle<double>, Slic3r::ConfigOptionFloat)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionSingleNullable<double>, Slic3r::ConfigOptionFloatNullable)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<double>, Slic3r::ConfigOptionFloats)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<double>, Slic3r::ConfigOptionFloatsNullable)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionSingle<int32_t>, Slic3r::ConfigOptionInt)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionSingleNullable<int32_t>, Slic3r::ConfigOptionIntNullable)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<int32_t>, Slic3r::ConfigOptionInts)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<int32_t>, Slic3r::ConfigOptionIntsNullable)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionSingle<std::string>, Slic3r::ConfigOptionString)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<std::string>, Slic3r::ConfigOptionStrings)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionFloat, Slic3r::ConfigOptionPercent)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionFloats, Slic3r::ConfigOptionPercents)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionFloats, Slic3r::ConfigOptionPercentsNullable)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionPercent, Slic3r::ConfigOptionFloatOrPercent)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<Slic3r::FloatOrPercent>, Slic3r::ConfigOptionFloatsOrPercents)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<Slic3r::FloatOrPercent>, Slic3r::ConfigOptionFloatsOrPercentsNullable)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionSingle<Slic3r::Vec2d>, Slic3r::ConfigOptionPoint)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<Slic3r::Vec2d>, Slic3r::ConfigOptionPoints)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionSingle<Slic3r::Vec3d>, Slic3r::ConfigOptionPoint3)
@@ -2398,6 +2400,5 @@ CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionSingle<Slic3r::GraphDat
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<Slic3r::GraphData>, Slic3r::ConfigOptionGraphs)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionSingle<bool>, Slic3r::ConfigOptionBool)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<unsigned char>, Slic3r::ConfigOptionBools)
-CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionVector<unsigned char>, Slic3r::ConfigOptionBoolsNullable)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigOptionInt, Slic3r::ConfigOptionEnumGeneric)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(Slic3r::ConfigBase, Slic3r::DynamicConfig)

--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -197,7 +197,6 @@ extern bool         unescape_strings_cstyle(const std::string &str, std::vector<
 
 extern std::string  escape_ampersand(const std::string& str);
 
-constexpr char NIL_STR_VALUE[] = "nil";
 
 enum class OptionCategory : int
 {
@@ -505,6 +504,8 @@ private:
     ConfigSubstitutions					    m_substitutions;
 };
 
+//note: is_nil is replaced by is_enabled
+
 // A generic value of a configuration option.
 class ConfigOption {
 public:
@@ -520,6 +521,7 @@ public:
         FCO_EXTRUDER_ARRAY = 1 << 1,
         FCO_PLACEHOLDER_TEMP = 1 << 2,
         FCO_ENABLED = 1 << 3,
+        FCO_CAN_DISABLED = 1 << 4,
     };
 
     ConfigOption() : flags(uint32_t(FCO_ENABLED)) { assert(this->flags != 0); }
@@ -541,15 +543,21 @@ public:
     // If scalar, idx is ignore, else: if idx < 0 return the vector; if idx >=0 then return the value at theis index; if idx >= size(), then return the first value or a default one.
     virtual boost::any          get_any(int32_t idx = -1)      const { throw BadOptionTypeException("Calling ConfigOption::get_any on a raw ConfigOption"); }
     virtual void                set_any(boost::any, int32_t idx = -1) { throw BadOptionTypeException("Calling ConfigOption::set_any on a raw ConfigOption"); }
-    virtual bool                is_enabled(size_t idx = -1)    const { return (flags & FCO_ENABLED) != 0; }
-    virtual ConfigOption *set_enabled(bool enabled, size_t idx = -1)
+    virtual bool                is_enabled(int32_t idx = -1)    const { return (flags & FCO_ENABLED) != 0; }
+    virtual ConfigOption*       set_enabled(bool enabled, int32_t idx = -1)
     {
+        assert(enabled || can_be_disabled());
         if (enabled)
             this->flags |= FCO_ENABLED;
         else
             this->flags &= uint32_t(0xFF ^ FCO_ENABLED);
         return this;
     }
+    // Like FCO_EXTRUDER_ARRAY that is a copy of the def, this is the copy of the def to replicate is_nullable()
+    bool                        can_be_disabled()		const { return (flags & FCO_CAN_DISABLED) != 0; }
+    // should only be set by configdef when a new item is requested.
+    ConfigOption*               set_can_be_disabled()	      { this->flags |= FCO_CAN_DISABLED; return this; }
+
     virtual bool                operator==(const ConfigOption &rhs) const = 0;
     bool                        operator!=(const ConfigOption &rhs) const { return ! (*this == rhs); }
     virtual size_t              hash()          const throw() = 0;
@@ -557,20 +565,19 @@ public:
     bool                        is_vector()     const { return ! this->is_scalar(); }
     // Size of the vector it contains, or 1 if it's a scalar value.
     virtual size_t              size()          const = 0;
-    // If this option is nullable, then it may have its value or values set to nil.
-    virtual bool 				nullable()		const { return false; }
-    // A scalar is nil, or all values of a vector are nil if idx < 0.
-    virtual bool                is_nil(int32_t idx = -1) const { return false; }
     bool                        is_phony()      const { return (flags & FCO_PHONY) != 0; }
     ConfigOption*               set_phony(bool phony) { if (phony) this->flags |= FCO_PHONY; else this->flags &= uint8_t(0xFF ^ FCO_PHONY); return this; }
     // Is this option overridden by another option?
-    // An option overrides another option if it is not nil and not equal.
-    virtual bool                overriden_by(const ConfigOption *rhs) const {
-    	assert(! this->nullable() && ! rhs->nullable());
-        return *this != *rhs && this->is_enabled() == rhs->is_enabled();
+    // An option overrides another option if enabled and not equal or the other isn't enabled.
+    virtual bool                overriden_by(const ConfigOption *rhs, int32_t idx = -1) const {
+        return rhs->is_enabled() && (*this != *rhs || !this->is_enabled());
     }
-    // Apply an override option, possibly a nullable one.
-    virtual bool                apply_override(const ConfigOption *rhs) {
+    // Apply an override option
+    virtual bool                apply_override(const ConfigOption *rhs, int32_t idx = -1) {
+        if (!rhs->is_enabled()) {
+            assert(false);
+            return false;
+        }
     	if (*this == *rhs) 
     		return false; 
     	*this = *rhs; 
@@ -584,64 +591,8 @@ private:
 typedef ConfigOption*       ConfigOptionPtr;
 typedef const ConfigOption* ConfigOptionConstPtr;
 
-// Nill value will be defined in specializations
-template<class T, class En = void> struct NilValueTempl
-{
-    using NilType = T;
-    static_assert(always_false<T>::value, "Type has no well defined nil value");
-};
-
-template<class T> struct NilValueTempl<T, std::enable_if_t<std::is_integral_v<T>, void>> {
-    using NilType = T;
-    static constexpr auto value = std::numeric_limits<T>::max();
-};
-
-template<> struct NilValueTempl<bool> : public NilValueTempl<int>{};
-
-// For enums the nil is the max value of the underlying type.
-template<class T>
-struct NilValueTempl<T, std::enable_if_t<std::is_enum_v<T>, void>>
-{
-    using NilType = T;
-    static constexpr auto value = static_cast<T>(std::numeric_limits<std::underlying_type_t<T>>::max());
-};
-
-// For Graph the nil is an empty array (there are no nil usage anyway)
-template<class T>
-struct NilValueTempl<T, std::enable_if_t<std::is_same<GraphData, T>::value, void>>
-{
-    using NilType = GraphData::GraphType;
-    static constexpr auto value = GraphData::GraphType::COUNT;
-};
-
-template<class T> struct NilValueTempl<T, std::enable_if_t<std::is_floating_point_v<T>, void>> {
-    using NilType = T;
-    static constexpr auto value = std::numeric_limits<T>::quiet_NaN();
-};
-
-template<>
-struct NilValueTempl<FloatOrPercent> : public NilValueTempl<double> {};
-
-template<> struct NilValueTempl<std::string> {
-    using NilType = const char *;
-
-    static constexpr const char* value = "";
-};
-
-template<int N, class T> struct NilValueTempl<Vec<N, T>> {
-    using NilType = Vec<N, T>;
-    // No constexpr for Vec<N, T>
-    static inline const Vec<N, T> value = Vec<N, T>::Ones() * NilValueTempl<remove_cvref_t<T>>::value;
-};
-
-template<class T> using NilType = typename NilValueTempl<remove_cvref_t<T>>::NilType;
-
-// Define shortcut as a function instead of a static const var so that it can be constexpr
-// even if the NilValueTempl::value is not constexpr.
-template<class T> static constexpr NilType<T> NilValue() noexcept { return NilValueTempl<remove_cvref_t<T>>::value; }
-
 // Value of a single valued option (bool, int, float, string, point, enum)
-template <class T, bool NULLABLE = false>
+template <class T>
 class ConfigOptionSingle : public ConfigOption {
 public:
     T value;
@@ -666,8 +617,7 @@ public:
             throw ConfigurationError("ConfigOptionSingle: Comparing incompatible types");
         }
         assert(dynamic_cast<const ConfigOptionSingle<T>*>(&rhs));
-        return (this->value == static_cast<const ConfigOptionSingle<T>*>(&rhs)->value 
-                || (this->is_nil() && rhs.is_nil()))
+        return this->value == static_cast<const ConfigOptionSingle<T>*>(&rhs)->value 
             && this->is_enabled() == rhs.is_enabled()
             && this->is_phony() == rhs.is_phony();
         // should compare all flags?
@@ -686,56 +636,36 @@ public:
     }
 
     // Is this option overridden by another option?
-    // An option overrides another option if it is not nil and not equal.
-    bool overriden_by(const ConfigOption *rhs) const override {
-        if (this->nullable())
-            throw ConfigurationError("Cannot override a nullable ConfigOption.");
+    // An option overrides another option if it is enabled and not equal.
+    bool overriden_by(const ConfigOption *rhs, int32_t idx = -1) const override {
+        //if (this->nullable())
+        //    throw ConfigurationError("Cannot override a nullable ConfigOption.");
         if (rhs->type() != this->type())
-            throw ConfigurationError("ConfigOptionVector.overriden_by() applied to different types.");
+            throw ConfigurationError("ConfigOptionSingle.overriden_by() applied to different types.");
         auto rhs_co = static_cast<const ConfigOptionSingle*>(rhs);
-        if (! rhs->nullable())
-            // Overridding a non-nullable object with another non-nullable object.
-            return this->value != rhs_co->value;
-
-        return !rhs_co->is_nil() && rhs_co->value != this->value;
+        return rhs_co->is_enabled() && (this->value != rhs_co->value || !this->is_enabled());
     }
-    // Apply an override option, possibly a nullable one.
-    bool apply_override(const ConfigOption *rhs) override {
-        if (this->nullable())
-            throw ConfigurationError("Cannot override a nullable ConfigOption.");
+    // Apply an override option, possibly a disabled one.
+    bool apply_override(const ConfigOption *rhs, int32_t idx = -1) override {
+        //if (this->nullable())
+        //    throw ConfigurationError("Cannot override a nullable ConfigOption.");
         if (rhs->type() != this->type())
-            throw ConfigurationError("ConfigOptionVector.apply_override() applied to different types.");
-        auto rhs_co = static_cast<const ConfigOptionSingle*>(rhs);
-        if (! rhs->nullable()) {
-            // Overridding a non-nullable object with another non-nullable object.
-            if (this->value != rhs_co->value) {
-                this->value = rhs_co->value;
-                return true;
-            }
+            throw ConfigurationError("ConfigOptionSingle.apply_override() applied to different types.");
+        if (!rhs->is_enabled()) {
+            assert(false);
             return false;
         }
-
-        if (!rhs_co->is_nil() && rhs_co->value != this->value) {
+        auto rhs_co = static_cast<const ConfigOptionSingle*>(rhs);
+        bool modified = false;
+        if (this->value != rhs_co->value) {
             this->value = rhs_co->value;
-            return true;
+            modified = true;
         }
-
-        return false;
-    }
-
-    bool nullable() const override { return NULLABLE; }
-
-    static constexpr NilType<T> nil_value() { return NilValue<T>(); }
-
-    // A scalar is nil, or all values of a vector are nil.
-    bool is_nil(int32_t idx = -1) const override
-    {
-        bool ret = false;
-
-        if constexpr (NULLABLE)
-            ret = this->value == nil_value();
-
-        return ret;
+        if (!this->is_enabled()) {
+            this->set_enabled(true);
+            modified = true;
+        }
+        return modified;
     }
 
 private:
@@ -743,16 +673,13 @@ private:
 	template<class Archive> void serialize(Archive & ar) { ar(this->flags); ar(this->value); }
 };
 
-template<class T>
-using ConfigOptionSingleNullable = ConfigOptionSingle<T, true>;
-
 // Value of a vector valued option (bools, ints, floats, strings, points)
 class ConfigOptionVectorBase : public ConfigOption {
 public:
     virtual std::string         serialize() const override = 0;
     virtual bool                deserialize(const std::string &str, bool append = false) override = 0;
     // Currently used only to initialize the PlaceholderParser.
-    virtual std::vector<std::string> vserialize() const = 0;
+    virtual std::string         serialize_at(int idx = 0) const = 0;
     // Set from a vector of ConfigOptions. 
     // If the rhs ConfigOption is scalar, then its value is used,
     // otherwise for each of rhs, the first value of a vector is used.
@@ -772,10 +699,9 @@ public:
 
     // Is this vector empty?
     virtual bool   empty() const = 0;
-    // Is the value nil? That should only be possible if this->nullable().
-    bool   is_nil(int32_t idx) const override = 0;
     // Get if the size of this vector is/should be the same as nozzle_diameter
     bool is_extruder_size() const { return (flags & FCO_EXTRUDER_ARRAY) != 0; }
+    // should only be set by configdef when a new item is requested.
     ConfigOptionVectorBase* set_is_extruder_size(bool is_extruder_size = true) {
         if (is_extruder_size) this->flags |= FCO_EXTRUDER_ARRAY; else this->flags &= uint8_t(0xFF ^ FCO_EXTRUDER_ARRAY);
         assert(this->flags != 0);
@@ -783,7 +709,7 @@ public:
     }
 
     
-    bool is_enabled(size_t idx = 0) const override {
+    bool is_enabled(int32_t idx = -1) const override {
         assert (m_enabled.size() == size());
         return idx >= 0 && idx < m_enabled.size() ? m_enabled[idx] : ConfigOption::is_enabled();
     }
@@ -792,7 +718,7 @@ public:
     {
         return this->m_enabled == rhs.m_enabled;
     }
-    ConfigOption *set_enabled(bool enabled, size_t idx = 0) override
+    ConfigOption *set_enabled(bool enabled, int32_t idx = -1) override
     {
         assert (m_enabled.size() == size());
         // reset evrything, use the default.
@@ -803,17 +729,25 @@ public:
             return this;
         }
         // can't enable something that doesn't exist
-        if(idx >= size())
+        if (idx >= size()) {
+            assert(false);
             return this;
+        }
         // set our value
         m_enabled[idx] = enabled;
         return this;
     }
 
+    bool has_enabled() const {
+        for (bool enabled : m_enabled)
+            if (enabled)
+                return true;
+        return false;
+    }
+
     // We just overloaded and hid two base class virtual methods.
     // Let's show it was intentional (warnings).
     using ConfigOption::set;
-    using ConfigOption::is_nil;
 
 
 protected:
@@ -976,6 +910,7 @@ public:
             this->m_values = boost::any_cast<std::vector<T>>(anyval);
             this->m_enabled.resize(this->m_values.size(), ConfigOption::is_enabled());
        } else {
+           assert(idx < size());
            set_at(boost::any_cast<T>(anyval), idx);
        }
         assert (m_enabled.size() == size());
@@ -1067,60 +1002,57 @@ public:
 
     // Is this option overridden by another option?
     // An option overrides another option if it is not nil and not equal
-    bool overriden_by(const ConfigOption *rhs) const override {
-        if (this->nullable())
-        	throw ConfigurationError("Cannot override a nullable ConfigOption.");
+    bool overriden_by(const ConfigOption *rhs, int32_t idx = -1) const override {
+        //if (this->nullable())
+        //	throw ConfigurationError("Cannot override a nullable ConfigOption.");
         if (rhs->type() != this->type())
             throw ConfigurationError("ConfigOptionVector.overriden_by() applied to different types.");
     	auto rhs_vec = static_cast<const ConfigOptionVector<T>*>(rhs);
-    	if (! rhs->nullable())
-    		// Overridding a non-nullable object with another non-nullable object.
-    		return this->m_values != rhs_vec->m_values && this->m_enabled != rhs_vec->m_enabled;
-    	size_t i = 0;
-    	size_t cnt = std::min(this->size(), rhs_vec->size());
-    	for (; i < cnt; ++ i)
-            if (! rhs_vec->is_nil(i) &&
-                (this->m_values[i] != rhs_vec->m_values[i] || this->is_enabled(i) != rhs_vec->is_enabled(i)))
-    			return true;
-    	for (; i < rhs_vec->size(); ++ i)
-    		if (! rhs_vec->is_nil(i))
-    			return true;
-    	return false;
+        assert(this->size() == rhs_vec->size());
+        if (idx < 0 || idx >= size()) {
+            // FIXME not exact.
+            return rhs_vec->has_enabled() && (this->m_values != rhs_vec->m_values || this->m_enabled != rhs_vec->m_enabled);
+        } else {
+            return rhs_vec->m_enabled[idx] && (this->m_values[idx] != rhs_vec->m_values[idx] || !this->m_enabled[idx]);
+        }
     }
 
     // Apply an override option, possibly a nullable one.
-    bool apply_override(const ConfigOption *rhs) override {
-        if (this->nullable())
-        	throw ConfigurationError("Cannot override a nullable ConfigOption.");
+    bool apply_override(const ConfigOption *rhs, int32_t idx = -1) override {
+        //if (this->nullable())
+        //	throw ConfigurationError("Cannot override a nullable ConfigOption.");
         if (rhs->type() != this->type())
 			throw ConfigurationError("ConfigOptionVector.apply_override() applied to different types.");
 		auto rhs_vec = static_cast<const ConfigOptionVector<T>*>(rhs);
-		if (! rhs->nullable()) {
-    		// Overridding a non-nullable object with another non-nullable object.
-    		if (this->m_values != rhs_vec->m_values || this->m_enabled != rhs_vec->m_enabled) {
-    			this->m_values = rhs_vec->m_values;
-    			this->m_enabled = rhs_vec->m_enabled;
-    			return true;
-    		}
-    		return false;
-    	}
-    	size_t i = 0;
-    	size_t cnt = std::min(this->size(), rhs_vec->size());
-    	bool   modified = false;
-    	for (; i < cnt; ++ i)
-    		if (! rhs_vec->is_nil(i) && this->m_values[i] != rhs_vec->m_values[i]) {
-    			this->m_values[i] = rhs_vec->m_values[i];
-    			this->m_enabled[i] = rhs_vec->m_enabled[i];
-    			modified = true;
-    		}
-    	for (; i < rhs_vec->size(); ++ i)
-    		if (! rhs_vec->is_nil(i)) {
-    			this->m_values.resize(i + 1, this->default_value);
-    			this->m_values[i] = rhs_vec->m_values[i];
-    			this->m_enabled[i] = rhs_vec->m_enabled[i];
-    			modified = true;
-    		}
-        return modified;
+        assert(this->size() == rhs_vec->size());
+        bool modified = false;
+        if (idx >= 0 && idx < this->size()) {
+            if (rhs_vec->m_enabled[idx]) {
+                if (this->m_values[idx] != rhs_vec->m_values[idx]) {
+                    this->m_values[idx] = rhs_vec->m_values[idx];
+                    modified = true;
+                }
+                if (!this->m_enabled[idx]) {
+                    this->m_enabled[idx] = true;
+                    modified = true;
+                }
+            }
+        } else {
+            // do it value per value
+            for (int i = 0; i < this->size(); ++i) {
+                if (rhs_vec->m_enabled[i]) {
+                    if (this->m_values[i] != rhs_vec->m_values[i]) {
+                        this->m_values[i] = rhs_vec->m_values[i];
+                        modified = true;
+                    }
+                    if (!this->m_enabled[i]) {
+                        this->m_enabled[i] = true;
+                        modified = true;
+                    }
+                }
+            }
+        }
+    	return modified;
     }
 
 private:
@@ -1128,30 +1060,26 @@ private:
 	template<class Archive> void serialize(Archive & ar) { ar(this->m_values); ar(cereal::base_class<ConfigOptionVectorBase>(this)); }
 };
 
-template<bool NULLABLE = false>
-class ConfigOptionFloatTempl : public ConfigOptionSingle<double, NULLABLE>
+class ConfigOptionFloat : public ConfigOptionSingle<double>
 {
 public:
-    ConfigOptionFloatTempl() : ConfigOptionSingle<double, NULLABLE>(0) {}
-    explicit ConfigOptionFloatTempl(double _value) : ConfigOptionSingle<double, NULLABLE>(_value) {}
+    ConfigOptionFloat() : ConfigOptionSingle<double>(0) {}
+    explicit ConfigOptionFloat(double _value) : ConfigOptionSingle<double>(_value) {}
 
     static ConfigOptionType static_type() { return coFloat; }
     ConfigOptionType        type()      const override { return static_type(); }
     double                  get_float(size_t idx = 0) const override { return this->value; }
-    ConfigOption*           clone()     const override { return new ConfigOptionFloatTempl(*this); }
-    bool                    operator==(const ConfigOptionFloatTempl &rhs) const throw() { return this->is_enabled() == rhs.is_enabled() && this->value == rhs.value; }
-    bool                    operator< (const ConfigOptionFloatTempl &rhs) const throw() { return this->is_enabled() < rhs.is_enabled() || (this->is_enabled() == rhs.is_enabled() && this->value < rhs.value); }
+    ConfigOption*           clone()     const override { return new ConfigOptionFloat(*this); }
+    bool                    operator==(const ConfigOptionFloat &rhs) const throw() { return this->is_enabled() == rhs.is_enabled() && this->value == rhs.value; }
+    bool                    operator< (const ConfigOptionFloat &rhs) const throw() { return this->is_enabled() < rhs.is_enabled() || (this->is_enabled() == rhs.is_enabled() && this->value < rhs.value); }
     
     std::string serialize() const override
     {
         std::ostringstream ss;
-        if (!this->is_enabled())
+        if (!this->is_enabled()) {
+            assert(this->can_be_disabled());
             ss << "!";
-        if (is_nil())
-            if (NULLABLE)
-                ss << "nil";
-            else
-                throw ConfigurationError("Serializing NaN");
+        }
         else if (std::isfinite(this->value)) {
             ss << this->value;
 
@@ -1169,90 +1097,44 @@ public:
             this->set_enabled(true);
         }
         std::istringstream iss(this->is_enabled() ? str : str.substr(1));
-
-        if (str == "nil") {
-            if (NULLABLE)
-                this->value = this->nil_value();
-            else
-                throw ConfigurationError("Deserializing nil into a non-nullable object");
-        } else {
-            iss >> this->value;
-        }
+        iss >> this->value;
 
         return !iss.fail();
     }
 
-    ConfigOptionFloatTempl& operator=(const ConfigOption *opt)
+    ConfigOptionFloat& operator=(const ConfigOption *opt)
     {   
         this->set(opt);
         return *this;
     }
 
-    bool is_nil(int32_t idx = -1) const override
-    {
-        return std::isnan(this->value) || this->value == ConfigOptionSingle<double, NULLABLE>::nil_value();
-    }
-
-    static inline bool is_any_nil(const boost::any &to_check) {
-        double dlb_val = boost::any_cast<double>(to_check);
-        return std::isnan(dlb_val) || dlb_val == ConfigOptionSingle<double, NULLABLE>::nil_value();
-    }
-
-    // don't use it to compare, use is_nil() to check.
-    static inline boost::any create_any_nil() { return boost::any(ConfigOptionSingle<double, NULLABLE>::nil_value()); }
-
 private:
 	friend class cereal::access;
-    template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionSingle<double, NULLABLE>>(this)); }
+    template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionSingle<double>>(this)); }
 };
 
-using ConfigOptionFloat = ConfigOptionFloatTempl<false>;
-using ConfigOptionFloatNullable  = ConfigOptionFloatTempl<true>;
-
-template<bool NULLABLE>
-class ConfigOptionFloatsTempl : public ConfigOptionVector<double>
+class ConfigOptionFloats : public ConfigOptionVector<double>
 {
 public:
-    ConfigOptionFloatsTempl() : ConfigOptionVector<double>() {}
-    explicit ConfigOptionFloatsTempl(double default_value) : ConfigOptionVector<double>(default_value) {}
-    explicit ConfigOptionFloatsTempl(size_t n, double value) : ConfigOptionVector<double>(n, value) {}
-    explicit ConfigOptionFloatsTempl(std::initializer_list<double> il) : ConfigOptionVector<double>(std::move(il)) {}
-    explicit ConfigOptionFloatsTempl(const std::vector<double> &vec) : ConfigOptionVector<double>(vec) {}
-    explicit ConfigOptionFloatsTempl(std::vector<double> &&vec) : ConfigOptionVector<double>(std::move(vec)) {}
+    ConfigOptionFloats() : ConfigOptionVector<double>() {}
+    explicit ConfigOptionFloats(double default_value) : ConfigOptionVector<double>(default_value) {}
+    explicit ConfigOptionFloats(size_t n, double value) : ConfigOptionVector<double>(n, value) {}
+    explicit ConfigOptionFloats(std::initializer_list<double> il) : ConfigOptionVector<double>(std::move(il)) {}
+    explicit ConfigOptionFloats(const std::vector<double> &vec) : ConfigOptionVector<double>(vec) {}
+    explicit ConfigOptionFloats(std::vector<double> &&vec) : ConfigOptionVector<double>(std::move(vec)) {}
 
     static ConfigOptionType static_type() { return coFloats; }
     ConfigOptionType        type()  const override { return static_type(); }
-    ConfigOption*           clone() const override { assert(this->m_values.size() == this->m_enabled.size()); return new ConfigOptionFloatsTempl(*this); }
-    bool                    operator==(const ConfigOptionFloatsTempl &rhs) const throw()
-    {
-        return this->m_enabled == rhs.m_enabled && vectors_equal(this->m_values, rhs.m_values);
-    }
-    bool operator<(const ConfigOptionFloatsTempl &rhs) const throw()
-    {
-        return this->m_enabled < rhs.m_enabled || (this->m_enabled == rhs.m_enabled && vectors_lower(this->m_values, rhs.m_values));
-    }
+    ConfigOption*           clone() const override { assert(this->m_values.size() == this->m_enabled.size()); return new ConfigOptionFloats(*this); }
+    bool                    operator==(const ConfigOptionFloats &rhs) const throw() { return this->m_enabled == rhs.m_enabled && this->m_values == rhs.m_values; }
+    bool operator<(const ConfigOptionFloats &rhs) const throw()
+        { return this->m_enabled < rhs.m_enabled || (this->m_enabled == rhs.m_enabled && this->m_values < rhs.m_values); }
     bool 					operator==(const ConfigOption &rhs) const override {
         if (rhs.type() != this->type())
-            throw ConfigurationError("ConfigOptionFloatsTempl: Comparing incompatible types");
+            throw ConfigurationError("ConfigOptionFloats: Comparing incompatible types");
         assert(dynamic_cast<const ConfigOptionVector<double>*>(&rhs));
         return this->has_same_enabled(*static_cast<const ConfigOptionVector<double> *>(&rhs)) &&
-               vectors_equal(this->m_values, static_cast<const ConfigOptionVector<double> *>(&rhs)->get_values());
-    }
-    // Could a special "nil" value be stored inside the vector, indicating undefined value?
-    bool 					nullable() const override { return NULLABLE; }
-    // A scalar is nil, or all values of a vector are nil.
-    bool                    is_nil(int32_t idx = -1) const override
-    {
-        if (idx < 0) {
-            for (double v : this->m_values)
-                if (!std::isnan(v) && v != ConfigOptionFloatNullable::nil_value())
-                    return false;
-            return true;
-        } else {
-            return idx < int32_t(this->size()) ? (std::isnan(this->m_values[idx])    || ConfigOptionFloatNullable::nil_value() == this->m_values[idx]) :
-                   this->empty()               ? (std::isnan(this->default_value)    || ConfigOptionFloatNullable::nil_value() == this->default_value) :
-                                                 (std::isnan(this->m_values.front()) || ConfigOptionFloatNullable::nil_value() == this->m_values.front());
-        }
+               this->m_values == static_cast<const ConfigOptionVector<double> *>(&rhs)->get_values();
     }
     double                  get_float(size_t idx = 0) const override { return get_at(idx); }
 
@@ -1268,17 +1150,12 @@ public:
         return ss.str();
     }
     
-    std::vector<std::string> vserialize() const override
+    std::string serialize_at(int idx) const override
     {
-        assert(this->m_values.size() == this->m_enabled.size());
-        std::vector<std::string> vv;
-        vv.reserve(this->m_values.size());
-        for (size_t idx = 0;idx < this->m_values.size(); ++idx) {
-            std::ostringstream ss;
-            this->serialize_single_value(ss, this->m_values[idx], this->m_enabled[idx]);
-            vv.push_back(ss.str());
-        }
-        return vv;
+        assert(idx >=0  && idx < size());
+        std::ostringstream ss;
+        this->serialize_single_value(ss, this->m_values[idx], this->m_enabled[idx]);
+        return ss.str();
     }
 
     bool deserialize(const std::string &str, bool append = false) override
@@ -1296,18 +1173,12 @@ public:
                 enabled = false;
                 item_str = item_str.substr(1);
                 boost::trim(item_str);
+                assert(this->can_be_disabled());
             }
-        	if (item_str == NIL_STR_VALUE) {
-        		if (NULLABLE)
-                    this->m_values.push_back(ConfigOptionFloatNullable::nil_value());
-        		else
-        			throw ConfigurationError("Deserializing nil into a non-nullable object");
-        	} else {
-	            std::istringstream iss(item_str);
-	            double value;
-	            iss >> value;
-                this->m_values.push_back(value);
-            }
+	        std::istringstream iss(item_str);
+	        double value;
+	        iss >> value;
+            this->m_values.push_back(value);
             this->m_enabled.push_back(enabled);
         }
         set_default_enabled();
@@ -1315,7 +1186,7 @@ public:
         return true;
     }
 
-    ConfigOptionFloatsTempl& operator=(const ConfigOption *opt)
+    ConfigOptionFloats& operator=(const ConfigOption *opt)
     {   
         this->set(opt);
         assert(this->m_values.size() == this->m_enabled.size());
@@ -1323,84 +1194,46 @@ public:
     }
 
 protected:
-    // Special "nil" value to be stored into the vector if this->supports_nil().
-    //please use is_nil & create_nil, to better support nan
-    //static double 			NIL_VALUE() { return std::numeric_limits<double>::quiet_NaN(); }
     void serialize_single_value(std::ostringstream &ss, const double v, const bool enabled) const {
-        if (!enabled)
+        if (!enabled) {
             ss << "!";
-        if (std::isnan(v) || v == ConfigOptionFloatNullable::nil_value())
-            if (NULLABLE)
-                ss << NIL_STR_VALUE;
-            else
-                throw ConfigurationError("Serializing NaN");
-        else if (std::isfinite(v)) {
+            assert(this->can_be_disabled());
+        }
+        if (std::isfinite(v)) {
             ss << v;
         } else
             throw ConfigurationError("Serializing invalid number");
 	}
-    static bool vectors_equal(const std::vector<double> &v1, const std::vector<double> &v2) {
-    	if (NULLABLE) {
-    		if (v1.size() != v2.size())
-    			return false;
-    		for (auto it1 = v1.begin(), it2 = v2.begin(); it1 != v1.end(); ++ it1, ++ it2)
-                if (!(((std::isnan(*it1) || *it1 == ConfigOptionFloatNullable::nil_value()) && (std::isnan(*it2) || *it2 == ConfigOptionFloatNullable::nil_value())) ||
-                      *it1 == *it2))
-	    			return false;
-    		return true;
-    	} else
-    		// Not supporting nullable values, the default vector compare is cheaper.
-    		return v1 == v2;
-    }
-    static bool vectors_lower(const std::vector<double> &v1, const std::vector<double> &v2) {
-        if (NULLABLE) {
-            for (auto it1 = v1.begin(), it2 = v2.begin(); it1 != v1.end() && it2 != v2.end(); ++ it1, ++ it2) {
-                auto null1 = int(std::isnan(*it1) || *it1 == ConfigOptionFloatNullable::nil_value());
-                auto null2 = int(std::isnan(*it2) || *it2 == ConfigOptionFloatNullable::nil_value());
-                return (null1 < null2) || (null1 == null2 && *it1 < *it2);
-            }
-            return v1.size() < v2.size();
-        } else
-            // Not supporting nullable values, the default vector compare is cheaper.
-            return v1 < v2;
-    }
 
 private:
 	friend class cereal::access;
 	template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionVector<double>>(this)); }
 };
 
-using ConfigOptionFloats 		 = ConfigOptionFloatsTempl<false>;
-using ConfigOptionFloatsNullable = ConfigOptionFloatsTempl<true>;
 
-template<bool NULLABLE = false>
-class ConfigOptionIntTempl : public ConfigOptionSingle<int32_t, NULLABLE>
+class ConfigOptionInt : public ConfigOptionSingle<int32_t>
 {
 public:
-    ConfigOptionIntTempl() : ConfigOptionSingle<int32_t, NULLABLE>(0) {}
-    explicit ConfigOptionIntTempl(int32_t value) : ConfigOptionSingle<int32_t, NULLABLE>(value) {}
-    explicit ConfigOptionIntTempl(double _value) : ConfigOptionSingle<int32_t, NULLABLE>(int32_t(floor(_value + 0.5))) {}
+    ConfigOptionInt() : ConfigOptionSingle<int32_t>(0) {}
+    explicit ConfigOptionInt(int32_t value) : ConfigOptionSingle<int32_t>(value) {}
+    explicit ConfigOptionInt(double _value) : ConfigOptionSingle<int32_t>(int32_t(floor(_value + 0.5))) {}
     
     static ConfigOptionType static_type() { return coInt; }
     ConfigOptionType        type()   const override { return static_type(); }
     int32_t                 get_int(size_t idx = 0) const override { return this->value; }
     double                  get_float(size_t idx = 0) const override { return this->value; }
-    ConfigOption*           clone()  const override { return new ConfigOptionIntTempl(*this); }
-    bool                    operator==(const ConfigOptionIntTempl &rhs) const throw() { return this->is_enabled() == rhs.is_enabled() && this->value == rhs.value; }
-    bool                    operator<(const ConfigOptionIntTempl &rhs) const throw() { return this->is_enabled() < rhs.is_enabled() || (this->is_enabled() == rhs.is_enabled() && this->value < rhs.value); }
+    ConfigOption*           clone()  const override { return new ConfigOptionInt(*this); }
+    bool                    operator==(const ConfigOptionInt &rhs) const throw() { return this->is_enabled() == rhs.is_enabled() && this->value == rhs.value; }
+    bool                    operator<(const ConfigOptionInt &rhs) const throw() { return this->is_enabled() < rhs.is_enabled() || (this->is_enabled() == rhs.is_enabled() && this->value < rhs.value); }
     
     std::string serialize() const override 
     {
         std::ostringstream ss;
-        if (!this->is_enabled())
+        if (!this->is_enabled()) {
             ss << "!";
-        if (this->value == this->nil_value()) {
-            if (NULLABLE)
-                ss << "nil";
-            else
-                throw ConfigurationError("Serializing NaN");
-        } else
-            ss << this->value;
+            assert(this->can_be_disabled());
+        }
+        ss << this->value;
 
         return ss.str();
     }
@@ -1410,80 +1243,44 @@ public:
         UNUSED(append);
         if (!str.empty() && str.front() == '!') {
             this->set_enabled(false);
+            assert(this->can_be_disabled());
         } else {
             this->set_enabled(true);
         }
         std::istringstream iss(this->is_enabled() ? str : str.substr(1));
 
-        if (str == "nil") {
-            if (NULLABLE)
-                this->value = this->nil_value();
-            else
-                throw ConfigurationError("Deserializing nil into a non-nullable object");
-        } else {
-            iss >> this->value;
-        }
+        iss >> this->value;
 
         return !iss.fail();
     }
 
-    ConfigOptionIntTempl& operator=(const ConfigOption *opt)
+    ConfigOptionInt& operator=(const ConfigOption *opt)
     {   
         this->set(opt);
         return *this;
     }
-    
-
-    static inline bool is_any_nil(const boost::any &to_check) {
-        return boost::any_cast<int32_t>(to_check) == ConfigOptionSingle<int32_t, NULLABLE>::nil_value();
-    }
-
-    // don't use it to compare, use is_nil() to check.
-    static inline boost::any create_any_nil() { return boost::any(ConfigOptionSingle<int32_t, NULLABLE>::nil_value()); }
 
 private:
 	friend class cereal::access;
-    template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionSingle<int32_t, NULLABLE>>(this)); }
+    template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionSingle<int32_t>>(this)); }
 };
 
-using ConfigOptionInt = ConfigOptionIntTempl<false>;
-using ConfigOptionIntNullable = ConfigOptionIntTempl<true>;
-
-template<bool NULLABLE>
-class ConfigOptionIntsTempl : public ConfigOptionVector<int32_t>
+class ConfigOptionInts : public ConfigOptionVector<int32_t>
 {
 public:
-    ConfigOptionIntsTempl() : ConfigOptionVector<int32_t>() {}
-    explicit ConfigOptionIntsTempl(int32_t default_value) : ConfigOptionVector<int32_t>(default_value) {}
-    explicit ConfigOptionIntsTempl(size_t n, int32_t value) : ConfigOptionVector<int32_t>(n, value) {}
-    explicit ConfigOptionIntsTempl(std::initializer_list<int32_t> &&il) : ConfigOptionVector<int32_t>(std::move(il)) {}
-    //explicit ConfigOptionIntsTempl(const std::vector<int> &v) : ConfigOptionVector<int>(v) {}
-    //explicit ConfigOptionIntsTempl(std::vector<int> &&v) : ConfigOptionVector<int>(std::move(v)) {}
+    ConfigOptionInts() : ConfigOptionVector<int32_t>() {}
+    explicit ConfigOptionInts(int32_t default_value) : ConfigOptionVector<int32_t>(default_value) {}
+    explicit ConfigOptionInts(size_t n, int32_t value) : ConfigOptionVector<int32_t>(n, value) {}
+    explicit ConfigOptionInts(std::initializer_list<int32_t> &&il) : ConfigOptionVector<int32_t>(std::move(il)) {}
+    //explicit ConfigOptionInts(const std::vector<int> &v) : ConfigOptionVector<int>(v) {}
+    //explicit ConfigOptionInts(std::vector<int> &&v) : ConfigOptionVector<int>(std::move(v)) {}
 
     static ConfigOptionType static_type() { return coInts; }
     ConfigOptionType        type()  const override { return static_type(); }
-    ConfigOption*           clone() const override { assert(this->m_values.size() == this->m_enabled.size()); return new ConfigOptionIntsTempl(*this); }
-    ConfigOptionIntsTempl&  operator= (const ConfigOption *opt) { this->set(opt); return *this; }
-    bool                    operator==(const ConfigOptionIntsTempl &rhs) const throw() { return this->m_enabled == rhs.m_enabled && this->m_values == rhs.m_values; }
-    bool                    operator< (const ConfigOptionIntsTempl &rhs) const throw() { return this->m_enabled < rhs.m_enabled || (this->m_enabled == rhs.m_enabled && this->m_values < rhs.m_values); }
-    // Could a special "nil" value be stored inside the vector, indicating undefined value?
-    bool 					nullable() const override { return NULLABLE; }
-    // Special "nil" value to be stored into the vector if this->supports_nil().
-    //static int32_t          NIL_VALUE() { return std::numeric_limits<int32_t>::max(); }
-    // A scalar is nil, or all values of a vector are nil.
-    bool is_nil(int32_t idx = -1) const override
-    {
-        if (idx < 0) {
-            for (int32_t v : this->m_values)
-                if (v != ConfigOptionIntNullable::nil_value())
-                    return false;
-            return true;
-        } else {
-            return idx < int32_t(this->size()) ? ConfigOptionIntNullable::nil_value() == this->m_values[idx] :
-                   this->empty()               ? ConfigOptionIntNullable::nil_value() == this->default_value :
-                                                 ConfigOptionIntNullable::nil_value() == this->get_at(0);
-        }
-    }
+    ConfigOption*           clone() const override { assert(this->m_values.size() == this->m_enabled.size()); return new ConfigOptionInts(*this); }
+    ConfigOptionInts&  operator= (const ConfigOption *opt) { this->set(opt); return *this; }
+    bool                    operator==(const ConfigOptionInts &rhs) const throw() { return this->m_enabled == rhs.m_enabled && this->m_values == rhs.m_values; }
+    bool                    operator< (const ConfigOptionInts &rhs) const throw() { return this->m_enabled < rhs.m_enabled || (this->m_enabled == rhs.m_enabled && this->m_values < rhs.m_values); }
     int32_t                 get_int(size_t idx = 0) const override { return get_at(idx); }
     double                  get_float(size_t idx = 0) const override { return get_at(idx); }
 
@@ -1498,16 +1295,12 @@ public:
         return ss.str();
     }
     
-    std::vector<std::string> vserialize() const override
+    std::string serialize_at(int idx) const override
     {
-        std::vector<std::string> vv;
-        vv.reserve(this->m_values.size());
-        for (size_t idx = 0;idx < this->m_values.size(); ++idx) {
-            std::ostringstream ss;
-            this->serialize_single_value(ss, this->m_values[idx], this->is_enabled(idx));
-            vv.push_back(ss.str());
-        }
-        return vv;
+        assert(idx >=0  && idx < size());
+        std::ostringstream ss;
+        this->serialize_single_value(ss, this->m_values[idx], this->m_enabled[idx]);
+        return ss.str();
     }
     
     bool deserialize(const std::string &str, bool append = false) override
@@ -1525,18 +1318,12 @@ public:
                 enabled  = false;
                 item_str = item_str.substr(1);
                 boost::trim(item_str);
+                assert(this->can_be_disabled());
             }
-        	if (item_str == NIL_STR_VALUE) {
-        		if (NULLABLE)
-                    this->m_values.push_back(ConfigOptionIntNullable::nil_value());
-        		else
-                    throw ConfigurationError("Deserializing nil into a non-nullable object");
-        	} else {
-	            std::istringstream iss(item_str);
-	            int32_t value;
-	            iss >> value;
-                this->m_values.push_back(value);
-            }
+	        std::istringstream iss(item_str);
+	        int32_t value;
+	        iss >> value;
+            this->m_values.push_back(value);
             this->m_enabled.push_back(enabled);
         }
         set_default_enabled();
@@ -1546,23 +1333,16 @@ public:
 
 private:
     void serialize_single_value(std::ostringstream &ss, const int32_t v, bool enabled) const {
-        if (!enabled)
+        if (!enabled) {
             ss << "!";
-        if (v == ConfigOptionIntNullable::nil_value()) {
-            if (NULLABLE)
-               ss << NIL_STR_VALUE;
-            else
-                throw ConfigurationError("Serializing NaN int");
-        } else
-            ss << v;
+            assert(this->can_be_disabled());
+        }
+        ss << v;
 	}
 
 	friend class cereal::access;
 	template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionVector<int32_t>>(this)); }
 };
-
-using ConfigOptionInts   	   = ConfigOptionIntsTempl<false>;
-using ConfigOptionIntsNullable = ConfigOptionIntsTempl<true>;
 
 class ConfigOptionString : public ConfigOptionSingle<std::string>
 {
@@ -1581,19 +1361,19 @@ public:
     std::string serialize() const override
     { 
         if (!this->is_enabled())
-            return std::string("!") + escape_string_cstyle(this->value);
+            return std::string("!:") + escape_string_cstyle(this->value);
         return escape_string_cstyle(this->value); 
     }
 
     bool deserialize(const std::string &str, bool append = false) override
     {
         UNUSED(append);
-        if (!str.empty() && str.front() == '!') {
+        if (str.size() > 1 && str.front() == '!' && str[1] == ':') {
             this->set_enabled(false);
         } else {
             this->set_enabled(true);
         }
-        return unescape_string_cstyle(this->is_enabled() ? str : str.substr(1), this->value);
+        return unescape_string_cstyle(this->is_enabled() ? str : str.substr(2), this->value);
     }
 
 private:
@@ -1618,7 +1398,6 @@ public:
     ConfigOptionStrings&    operator=(const ConfigOption *opt) { this->set(opt); return *this; }
     bool                    operator==(const ConfigOptionStrings &rhs) const throw() { return this->m_enabled == rhs.m_enabled && this->m_values == rhs.m_values; }
     bool                    operator< (const ConfigOptionStrings &rhs) const throw() { return this->m_enabled < rhs.m_enabled || (this->m_enabled == rhs.m_enabled && this->m_values < rhs.m_values); }
-    bool                    is_nil(int32_t idx = 0) const override { return false; }
 
     std::string serialize() const override
     {
@@ -1630,9 +1409,12 @@ public:
         return escape_strings_cstyle(this->m_values, this->m_enabled);
     }
     
-    std::vector<std::string> vserialize() const override
+    std::string serialize_at(int idx) const override
     {
-        return this->m_values;
+        assert(idx >=0  && idx < size());
+        if (!this->is_enabled(idx))
+            return std::string("!:") + escape_string_cstyle(this->get_at(idx));
+        return escape_string_cstyle(this->get_at(idx)); 
     }
     
     bool deserialize(const std::string &str, bool append = false) override
@@ -1674,8 +1456,10 @@ public:
     std::string serialize() const override 
     {
         std::ostringstream ss;
-        if (!this->is_enabled())
+        if (!this->is_enabled()) {
             ss << "!";
+            assert(this->can_be_disabled());
+        }
         ss << this->value;
         std::string s(ss.str());
         s += "%";
@@ -1687,6 +1471,7 @@ public:
         UNUSED(append);
         if (!str.empty() && str.front() == '!') {
             this->set_enabled(false);
+            assert(this->can_be_disabled());
         } else {
             this->set_enabled(true);
         }
@@ -1701,30 +1486,24 @@ private:
 	template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionFloat>(this)); }
 };
 
-template<bool NULLABLE>
-class ConfigOptionPercentsTempl : public ConfigOptionFloatsTempl<NULLABLE>
+class ConfigOptionPercents : public ConfigOptionFloats
 {
 public:
-    ConfigOptionPercentsTempl() : ConfigOptionFloatsTempl<NULLABLE>() {}
-    explicit ConfigOptionPercentsTempl(double default_value) : ConfigOptionFloatsTempl<NULLABLE>(default_value) {}
-    explicit ConfigOptionPercentsTempl(size_t n, double value) : ConfigOptionFloatsTempl<NULLABLE>(n, value) {}
-    explicit ConfigOptionPercentsTempl(std::initializer_list<double> il) : ConfigOptionFloatsTempl<NULLABLE>(std::move(il)) {}
-    explicit ConfigOptionPercentsTempl(const std::vector<double>& vec) : ConfigOptionFloatsTempl<NULLABLE>(vec) {}
-    explicit ConfigOptionPercentsTempl(std::vector<double>&& vec) : ConfigOptionFloatsTempl<NULLABLE>(std::move(vec)) {}
+    ConfigOptionPercents() : ConfigOptionFloats() {}
+    explicit ConfigOptionPercents(double default_value) : ConfigOptionFloats(default_value) {}
+    explicit ConfigOptionPercents(size_t n, double value) : ConfigOptionFloats(n, value) {}
+    explicit ConfigOptionPercents(std::initializer_list<double> il) : ConfigOptionFloats(std::move(il)) {}
+    explicit ConfigOptionPercents(const std::vector<double>& vec) : ConfigOptionFloats(vec) {}
+    explicit ConfigOptionPercents(std::vector<double>&& vec) : ConfigOptionFloats(std::move(vec)) {}
 
     static ConfigOptionType static_type() { return coPercents; }
     ConfigOptionType        type()  const override { return static_type(); }
-    ConfigOption*           clone() const override { assert(this->m_values.size() == this->m_enabled.size()); return new ConfigOptionPercentsTempl(*this); }
-    ConfigOptionPercentsTempl& operator=(const ConfigOption *opt) { this->set(opt); return *this; }
-    bool operator==(const ConfigOptionPercentsTempl &rhs) const throw()
-    {
-        return this->m_enabled == rhs.m_enabled && ConfigOptionFloatsTempl<NULLABLE>::vectors_equal(this->m_values, rhs.m_values);
-    }
-    bool operator<(const ConfigOptionPercentsTempl &rhs) const throw()
-    {
-        return this->m_enabled < rhs.m_enabled || (this->m_enabled == rhs.m_enabled && ConfigOptionFloatsTempl<NULLABLE>::vectors_lower(this->m_values, rhs.m_values));
-    }
-    double                  get_abs_value(size_t i, double ratio_over) const { return this->is_nil(i) ? 0 : ratio_over * this->get_at(i) / 100; }
+    ConfigOption*           clone() const override { assert(this->m_values.size() == this->m_enabled.size()); return new ConfigOptionPercents(*this); }
+    ConfigOptionPercents& operator=(const ConfigOption *opt) { this->set(opt); return *this; }
+    bool operator==(const ConfigOptionPercents &rhs) const throw() { return this->m_enabled == rhs.m_enabled && this->m_values == rhs.m_values; }
+    bool operator<(const ConfigOptionPercents &rhs) const throw()
+        { return this->m_enabled < rhs.m_enabled || (this->m_enabled == rhs.m_enabled && this->m_values < rhs.m_values); }
+    double                  get_abs_value(size_t i, double ratio_over) const { return ratio_over * this->get_at(i) / 100; }
     bool                    is_percent(size_t idx = 0) const override { return true; }
 
     std::string serialize() const override
@@ -1734,25 +1513,18 @@ public:
             if (idx > 0)
                 ss << ",";
             this->serialize_single_value(ss, this->m_values[idx], this->is_enabled(idx));
-            if (! (std::isnan(this->m_values[idx]) || this->m_values[idx] == ConfigOptionFloatNullable::nil_value()))
-                ss << "%";
+            ss << "%";
         }
         std::string str = ss.str();
         return str;
     }
-
-    std::vector<std::string> vserialize() const override
+    
+    std::string serialize_at(int idx) const override
     {
-        std::vector<std::string> vv;
-        vv.reserve(this->m_values.size());
-        for (size_t idx = 0;idx < this->m_values.size(); ++idx) {
-            std::ostringstream ss;
-            this->serialize_single_value(ss, this->m_values[idx], this->is_enabled(idx));
-            if (! (std::isnan(this->m_values[idx]) || this->m_values[idx] == ConfigOptionFloatNullable::nil_value()))
-                ss << "%";
-            vv.push_back(ss.str());
-        }
-        return vv;
+        assert(idx >=0  && idx < size());
+        std::ostringstream ss;
+        this->serialize_single_value(ss, this->m_values[idx], this->m_enabled[idx]);
+        return ss.str();
     }
 
     // The float's deserialize function shall ignore the trailing optional %.
@@ -1760,11 +1532,8 @@ public:
 
 private:
 	friend class cereal::access;
-	template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionFloatsTempl<NULLABLE>>(this)); }
+	template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionFloats>(this)); }
 };
-
-using ConfigOptionPercents 	   		= ConfigOptionPercentsTempl<false>;
-using ConfigOptionPercentsNullable 	= ConfigOptionPercentsTempl<true>;
 
 class ConfigOptionFloatOrPercent : public ConfigOptionPercent
 {
@@ -1787,7 +1556,7 @@ public:
     bool                        operator==(const ConfigOptionFloatOrPercent &rhs) const throw()
         { return this->is_enabled() == rhs.is_enabled() && this->value == rhs.value && this->percent == rhs.percent; }
     size_t                      hash() const throw() override 
-        { size_t seed = std::hash<double>{}(this->value); return this->percent ? seed ^ 0x9e3779b9 : seed; }
+        { if(!is_enabled()) return 0; size_t seed = std::hash<double>{}(this->value); return this->percent ? seed ^ 0x9e3779b9 : seed; }
     bool                        operator< (const ConfigOptionFloatOrPercent &rhs) const throw() {
         bool this_enabled = this->is_enabled();
         bool rhs_enabled = this->is_enabled();
@@ -1817,8 +1586,10 @@ public:
     std::string serialize() const override
     {
         std::ostringstream ss;
-        if (!this->is_enabled())
+        if (!this->is_enabled()) {
             ss << "!";
+            assert(this->can_be_disabled());
+        }
         ss << this->value;
         std::string s(ss.str());
         if (this->percent) s += "%";
@@ -1830,6 +1601,7 @@ public:
         UNUSED(append);
         if (!str.empty() && str.front() == '!') {
             this->set_enabled(false);
+            assert(this->can_be_disabled());
         } else {
             this->set_enabled(true);
         }
@@ -1844,74 +1616,38 @@ private:
 	template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionPercent>(this), percent); }
 };
 
-template<bool NULLABLE>
-class ConfigOptionFloatsOrPercentsTempl : public ConfigOptionVector<FloatOrPercent>
+class ConfigOptionFloatsOrPercents : public ConfigOptionVector<FloatOrPercent>
 {
 public:
-    ConfigOptionFloatsOrPercentsTempl() : ConfigOptionVector<FloatOrPercent>() {}
-    explicit ConfigOptionFloatsOrPercentsTempl(FloatOrPercent default_value) : ConfigOptionVector<FloatOrPercent>(default_value) {}
-    explicit ConfigOptionFloatsOrPercentsTempl(size_t n, FloatOrPercent value) : ConfigOptionVector<FloatOrPercent>(n, value) {}
-    explicit ConfigOptionFloatsOrPercentsTempl(std::initializer_list<FloatOrPercent> il) : ConfigOptionVector<FloatOrPercent>(std::move(il)) {}
-    explicit ConfigOptionFloatsOrPercentsTempl(const std::vector<FloatOrPercent> &vec) : ConfigOptionVector<FloatOrPercent>(vec) {}
-    explicit ConfigOptionFloatsOrPercentsTempl(std::vector<FloatOrPercent> &&vec) : ConfigOptionVector<FloatOrPercent>(std::move(vec)) {}
+    ConfigOptionFloatsOrPercents() : ConfigOptionVector<FloatOrPercent>() {}
+    explicit ConfigOptionFloatsOrPercents(FloatOrPercent default_value) : ConfigOptionVector<FloatOrPercent>(default_value) {}
+    explicit ConfigOptionFloatsOrPercents(size_t n, FloatOrPercent value) : ConfigOptionVector<FloatOrPercent>(n, value) {}
+    explicit ConfigOptionFloatsOrPercents(std::initializer_list<FloatOrPercent> il) : ConfigOptionVector<FloatOrPercent>(std::move(il)) {}
+    explicit ConfigOptionFloatsOrPercents(const std::vector<FloatOrPercent> &vec) : ConfigOptionVector<FloatOrPercent>(vec) {}
+    explicit ConfigOptionFloatsOrPercents(std::vector<FloatOrPercent> &&vec) : ConfigOptionVector<FloatOrPercent>(std::move(vec)) {}
 
     static ConfigOptionType static_type() { return coFloatsOrPercents; }
     ConfigOptionType        type()  const override { return static_type(); }
-    ConfigOption*           clone() const override { assert(this->m_values.size() == this->m_enabled.size()); return new ConfigOptionFloatsOrPercentsTempl(*this); }
-    bool                    operator==(const ConfigOptionFloatsOrPercentsTempl &rhs) const throw()
-    {
-        return this->m_enabled == rhs.m_enabled && vectors_equal(this->m_values, rhs.m_values);
-    }
+    ConfigOption*           clone() const override { assert(this->m_values.size() == this->m_enabled.size()); return new ConfigOptionFloatsOrPercents(*this); }
+    bool                    operator==(const ConfigOptionFloatsOrPercents &rhs) const throw()
+        { return this->m_enabled == rhs.m_enabled && this->m_values == rhs.m_values; }
     bool                    operator==(const ConfigOption &rhs) const override
     {
         if (rhs.type() != this->type())
-            throw ConfigurationError("ConfigOptionFloatsOrPercentsTempl: Comparing incompatible types");
+            throw ConfigurationError("ConfigOptionFloatsOrPercents: Comparing incompatible types");
         assert(dynamic_cast<const ConfigOptionVector<FloatOrPercent> *>(&rhs));
         return this->has_same_enabled(*static_cast<const ConfigOptionVector<FloatOrPercent> *>(&rhs)) &&
-               vectors_equal(this->m_values, static_cast<const ConfigOptionVector<FloatOrPercent> *>(&rhs)->get_values());
+               this->m_values == static_cast<const ConfigOptionVector<FloatOrPercent> *>(&rhs)->get_values();
     }
-    bool                    operator<(const ConfigOptionFloatsOrPercentsTempl &rhs) const throw()
-    {
-        return this->m_enabled < rhs.m_enabled || (this->m_enabled == rhs.m_enabled && vectors_lower(this->m_values, rhs.m_values));
-    }
-
-    // Could a special "nil" value be stored inside the vector, indicating undefined value?
-    bool                    nullable() const override { return NULLABLE; }
-    // A scalar is nil, or all values of a vector are nil.
-    bool                    is_nil(int32_t idx = -1) const override
-    {
-        if (idx < 0) {
-            for (const FloatOrPercent &v : this->m_values)
-                if (!(std::isnan(v.value) || v.value == NIL_VALUE().value || v.value > std::numeric_limits<float>::max()))
-                    return false;
-            return true;
-        } else {
-            return idx < int32_t(this->size()) ? (std::isnan(this->m_values[idx].value) || NIL_VALUE() == this->m_values[idx]) :
-                   this->empty()               ? (std::isnan(this->default_value.value) || NIL_VALUE() == this->default_value) :
-                                                 (std::isnan(this->m_values.front().value) || NIL_VALUE() == this->m_values.front());
-        }
-    }
+    bool                    operator<(const ConfigOptionFloatsOrPercents &rhs) const throw()
+        { return this->m_enabled < rhs.m_enabled || (this->m_enabled == rhs.m_enabled && this->m_values < rhs.m_values); }
     double                  get_abs_value(size_t i, double ratio_over) const {
-        if (this->is_nil(i)) return 0;
         const FloatOrPercent& data = this->get_at(i);
         if (data.percent) return ratio_over * data.value / 100;
         return data.value;
     }
     double                  get_float(size_t idx = 0) const override { return get_abs_value(idx, 1.); }
-    bool                    is_percent(size_t idx = 0) const override
-    {
-        if (this->is_nil(idx))
-            return false;
-        return this->get_at(idx).percent;
-    }
-
-    static inline bool is_any_nil(const boost::any &to_check) {
-        bool ok = std::isnan(boost::any_cast<FloatOrPercent>(to_check).value) || boost::any_cast<FloatOrPercent>(to_check).value == NIL_VALUE().value
-            || boost::any_cast<FloatOrPercent>(to_check).value > std::numeric_limits<float>::max();
-        return ok;
-    }
-    // don't use it to compare, use is_nil() to check.
-    static inline boost::any create_any_nil() { return boost::any(NIL_VALUE()); }
+    bool                    is_percent(size_t idx = 0) const override { return this->get_at(idx).percent; }
 
     std::string serialize() const override
     {
@@ -1924,16 +1660,12 @@ public:
         return ss.str();
     }
     
-    std::vector<std::string> vserialize() const override
+    std::string serialize_at(int idx) const override
     {
-        std::vector<std::string> vv;
-        vv.reserve(this->m_values.size());
-        for (size_t idx = 0;idx < this->m_values.size(); ++idx) {
-            std::ostringstream ss;
-            this->serialize_single_value(ss, this->m_values[idx], this->is_enabled(idx));
-            vv.push_back(ss.str());
-        }
-        return vv;
+        assert(idx >=0  && idx < size());
+        std::ostringstream ss;
+        this->serialize_single_value(ss, this->m_values[idx], this->m_enabled[idx]);
+        return ss.str();
     }
 
     bool deserialize(const std::string &str, bool append = false) override
@@ -1951,19 +1683,13 @@ public:
                 enabled = false;
                 item_str = item_str.substr(1);
                 boost::trim(item_str);
+                assert(this->can_be_disabled());
             }
-            if (item_str == NIL_STR_VALUE) {
-                if (NULLABLE)
-                    this->m_values.push_back(NIL_VALUE());
-                else
-                    throw ConfigurationError("Deserializing nil into a non-nullable object");
-            } else {
-                bool percent = item_str.find_first_of("%") != std::string::npos;
-                std::istringstream iss(item_str);
-                double value;
-                iss >> value;
-                this->m_values.push_back({ value, percent });
-            }
+            bool percent = item_str.find_first_of("%") != std::string::npos;
+            std::istringstream iss(item_str);
+            double value;
+            iss >> value;
+            this->m_values.push_back({ value, percent });
             this->m_enabled.push_back(enabled);
         }
         set_default_enabled();
@@ -1971,7 +1697,7 @@ public:
         return true;
     }
 
-    ConfigOptionFloatsOrPercentsTempl& operator=(const ConfigOption *opt)
+    ConfigOptionFloatsOrPercents& operator=(const ConfigOption *opt)
     {   
         this->set(opt);
         return *this;
@@ -1982,54 +1708,22 @@ protected:
     static FloatOrPercent   NIL_VALUE() { return FloatOrPercent{ std::numeric_limits<double>::max(), false }; }
 
     void serialize_single_value(std::ostringstream &ss, const FloatOrPercent &v, bool enabled) const {
-        if (!enabled)
+        if (!enabled) {
             ss << "!";
+            assert(this->can_be_disabled());
+        }
         if (std::isfinite(v.value)) {
             ss << v.value;
             if (v.percent)
                 ss << "%";
-        } else if (std::isnan(v.value) || v.value == NIL_VALUE().value || v.value > std::numeric_limits<float>::max()) {
-            if (NULLABLE)
-                ss << NIL_STR_VALUE;
-            else
-                throw ConfigurationError("Serializing NaN");
         } else
             throw ConfigurationError("Serializing invalid number");
-    }
-    static bool vectors_equal(const std::vector<FloatOrPercent> &v1, const std::vector<FloatOrPercent> &v2) {
-        if (NULLABLE) {
-            if (v1.size() != v2.size())
-                return false;
-            for (auto it1 = v1.begin(), it2 = v2.begin(); it1 != v1.end(); ++ it1, ++ it2)
-                if (!(((std::isnan(it1->value) || it1->value == NIL_VALUE().value || it1->value > std::numeric_limits<float>::max()) &&
-                       (std::isnan(it2->value) || it2->value == NIL_VALUE().value || it1->value > std::numeric_limits<float>::max())) ||
-                      *it1 == *it2))
-                    return false;
-            return true;
-        } else
-            // Not supporting nullable values, the default vector compare is cheaper.
-            return v1 == v2;
-    }
-    static bool vectors_lower(const std::vector<FloatOrPercent> &v1, const std::vector<FloatOrPercent> &v2) {
-        if (NULLABLE) {
-            for (auto it1 = v1.begin(), it2 = v2.begin(); it1 != v1.end() && it2 != v2.end(); ++ it1, ++ it2) {
-                auto null1 = int(std::isnan(it1->value) || it1->value == NIL_VALUE().value || it1->value > std::numeric_limits<float>::max());
-                auto null2 = int(std::isnan(it2->value) || it2->value == NIL_VALUE().value || it1->value > std::numeric_limits<float>::max());
-                return (null1 < null2) || (null1 == null2 && *it1 < *it2);
-            }
-            return v1.size() < v2.size();
-        } else
-            // Not supporting nullable values, the default vector compare is cheaper.
-            return v1 < v2;
     }
 
 private:
     friend class cereal::access;
     template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionVector<FloatOrPercent>>(this)); }
 };
-
-using ConfigOptionFloatsOrPercents          = ConfigOptionFloatsOrPercentsTempl<false>;
-using ConfigOptionFloatsOrPercentsNullable  = ConfigOptionFloatsOrPercentsTempl<true>;
 
 class ConfigOptionPoint : public ConfigOptionSingle<Vec2d>
 {
@@ -2110,15 +1804,17 @@ public:
                std::lexicographical_compare(this->m_values.begin(), this->m_values.end(), rhs.m_values.begin(),
                                             rhs.m_values.end(), [](const auto &l, const auto &r) { return l < r; }));
     }
-    bool                    is_nil(int32_t idx = 0) const override { return false; }
 
     std::string serialize() const override
     {
         std::ostringstream ss;
         for (size_t idx = 0 ; idx < this->m_values.size(); ++idx) {
             if (idx != 0) ss << ",";
-            if (!m_enabled[idx])
+            assert(m_enabled.size() == m_values.size());
+            if (!m_enabled[idx]) {
                 ss << "!";
+                assert(this->can_be_disabled());
+            }
             ss << this->m_values[idx].x();
             ss << "x";
             ss << this->m_values[idx].y();
@@ -2126,15 +1822,18 @@ public:
         return ss.str();
     }
     
-    std::vector<std::string> vserialize() const override
+    std::string serialize_at(int idx) const override
     {
-        std::vector<std::string> vv;
-        for (Pointfs::const_iterator it = this->m_values.begin(); it != this->m_values.end(); ++it) {
-            std::ostringstream ss;
-            ss << *it;
-            vv.push_back(ss.str());
+        assert(idx >=0  && idx < size());
+        std::ostringstream ss;
+        if (!m_enabled[idx]) {
+            ss << "!";
+            assert(this->can_be_disabled());
         }
-        return vv;
+        ss << this->m_values[idx].x();
+        ss << "x";
+        ss << this->m_values[idx].y();
+        return ss.str();
     }
     
     bool deserialize(const std::string &str, bool append = false) override
@@ -2151,6 +1850,7 @@ public:
             if (!point_str.empty() && point_str.front() == '!') {
                 enabled = false;
                 point_str = point_str.substr(1);
+                assert(this->can_be_disabled());
             }
             Vec2d point(Vec2d::Zero());
             std::istringstream iss(point_str);
@@ -2303,7 +2003,6 @@ public:
             std::lexicographical_compare(this->m_values.begin(), this->m_values.end(), rhs.m_values.begin(),
                                             rhs.m_values.end(), [](const auto &l, const auto &r) { return l < r; }));
     }
-    bool                    is_nil(int32_t idx = 0) const override { return false; }
 
     std::string serialize() const override
     {
@@ -2311,23 +2010,25 @@ public:
         for (size_t idx = 0; idx < size(); ++idx) {
             const GraphData &graph = this->m_values[idx];
             if (idx != 0) ss << ",";
-            if (!this->is_enabled(idx)) ss << "!";
+            if (!this->is_enabled(idx)) {
+                ss << "!";
+                assert(this->can_be_disabled());
+            }
             ss << graph.serialize();
         }
         return ss.str();
     }
-
-    std::vector<std::string> vserialize() const override
+    
+    std::string serialize_at(int idx) const override
     {
-        std::vector<std::string> vv;
-        for (size_t idx = 0; idx < size(); ++idx) {
-            const GraphData &graph = this->m_values[idx];
-            std::ostringstream ss;
-            if (!this->is_enabled(idx)) ss << "!";
-            ss << graph.serialize();
-            vv.push_back(ss.str());
+        assert(idx >=0  && idx < size());
+        std::ostringstream ss;
+        if (!this->is_enabled(idx)) {
+            ss << "!";
+            assert(this->can_be_disabled());
         }
-        return vv;
+        ss << this->m_values[idx].serialize();
+        return ss.str();
     }
     
     bool deserialize(const std::string &str, bool append = false) override
@@ -2348,6 +2049,7 @@ public:
                 enabled = false;
                 graph_str = graph_str.substr(1);
                 boost::trim(graph_str);
+                assert(this->can_be_disabled());
             }
             GraphData graph;
             bool ok = graph.deserialize(graph_str);
@@ -2429,54 +2131,35 @@ private:
 	template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionSingle<bool>>(this)); }
 };
 
-template<bool NULLABLE>
-class ConfigOptionBoolsTempl : public ConfigOptionVector<unsigned char>
+class ConfigOptionBools : public ConfigOptionVector<unsigned char>
 {
 public:
-    ConfigOptionBoolsTempl() : ConfigOptionVector<unsigned char>() {}
-    explicit ConfigOptionBoolsTempl(bool default_value) : ConfigOptionVector<unsigned char>(default_value) {}
-    explicit ConfigOptionBoolsTempl(size_t n, bool value) : ConfigOptionVector<unsigned char>(n, (unsigned char)value) {}
-    explicit ConfigOptionBoolsTempl(std::initializer_list<bool> il)
+    ConfigOptionBools() : ConfigOptionVector<unsigned char>() {}
+    explicit ConfigOptionBools(bool default_value) : ConfigOptionVector<unsigned char>(default_value) {}
+    explicit ConfigOptionBools(size_t n, bool value) : ConfigOptionVector<unsigned char>(n, (unsigned char)value) {}
+    explicit ConfigOptionBools(std::initializer_list<bool> il)
     {
         this->m_values.reserve(il.size());
         for (bool b : il) this->m_values.emplace_back((unsigned char) b);
         this->m_enabled.resize(this->m_values.size(), ConfigOption::is_enabled());
         assert(m_enabled.size() == size());
     }
-    explicit ConfigOptionBoolsTempl(std::initializer_list<unsigned char> il)
+    explicit ConfigOptionBools(std::initializer_list<unsigned char> il)
     {
         this->m_values.reserve(il.size());
         for (unsigned char b : il) this->m_values.emplace_back(b);
         this->m_enabled.resize(this->m_values.size(), ConfigOption::is_enabled());
         assert(m_enabled.size() == size());
     }
-	explicit ConfigOptionBoolsTempl(const std::vector<unsigned char>& vec) : ConfigOptionVector<unsigned char>(vec) {}
-	explicit ConfigOptionBoolsTempl(std::vector<unsigned char>&& vec) : ConfigOptionVector<unsigned char>(std::move(vec)) {}
+	explicit ConfigOptionBools(const std::vector<unsigned char>& vec) : ConfigOptionVector<unsigned char>(vec) {}
+	explicit ConfigOptionBools(std::vector<unsigned char>&& vec) : ConfigOptionVector<unsigned char>(std::move(vec)) {}
 
     static ConfigOptionType static_type() { return coBools; }
     ConfigOptionType        type()  const override { return static_type(); }
-    ConfigOption*           clone() const override { assert(this->m_values.size() == this->m_enabled.size()); return new ConfigOptionBoolsTempl(*this); }
-    ConfigOptionBoolsTempl& operator=(const ConfigOption *opt) { this->set(opt); return *this; }
-    bool                    operator==(const ConfigOptionBoolsTempl &rhs) const throw() { return this->m_enabled == rhs.m_enabled && this->m_values == rhs.m_values; }
-    bool                    operator< (const ConfigOptionBoolsTempl &rhs) const throw() { return this->m_enabled < rhs.m_enabled || (this->m_enabled == rhs.m_enabled && this->m_values <  rhs.m_values); }
-    // Could a special "nil" value be stored inside the vector, indicating undefined value?
-    bool 					nullable() const override { return NULLABLE; }
-    // Special "nil" value to be stored into the vector if this->supports_nil().
-    static unsigned char    NIL_VALUE() { return std::numeric_limits<unsigned char>::max(); }
-    // A scalar is nil, or all values of a vector are nil.
-    bool is_nil(int32_t idx = -1) const override
-    {
-        if (idx < 0) {
-            for (uint8_t v : this->m_values)
-                if (v != NIL_VALUE())
-                    return false;
-            return true;
-        } else {
-            return idx < int32_t(this->size()) ? NIL_VALUE() == this->m_values[idx] :
-                   this->empty()               ? NIL_VALUE() == this->default_value :
-                                                 NIL_VALUE() == this->m_values.front();
-    }
-    }
+    ConfigOption*           clone() const override { assert(this->m_values.size() == this->m_enabled.size()); return new ConfigOptionBools(*this); }
+    ConfigOptionBools& operator=(const ConfigOption *opt) { this->set(opt); return *this; }
+    bool                    operator==(const ConfigOptionBools &rhs) const throw() { return this->m_enabled == rhs.m_enabled && this->m_values == rhs.m_values; }
+    bool                    operator< (const ConfigOptionBools &rhs) const throw() { return this->m_enabled < rhs.m_enabled || (this->m_enabled == rhs.m_enabled && this->m_values <  rhs.m_values); }
     bool                    get_bool(size_t idx = 0) const override { return ConfigOptionVector<unsigned char>::get_at(idx) != 0; }
     int32_t                 get_int(size_t idx = 0) const override { return ConfigOptionVector<unsigned char>::get_at(idx) != 0 ? 1 : 0; }
     double                  get_float(size_t idx = 0) const override { return ConfigOptionVector<unsigned char>::get_at(idx) != 0 ? 1. : 0.; }
@@ -2492,15 +2175,12 @@ public:
         return ss.str();
     }
     
-    std::vector<std::string> vserialize() const override
+    std::string serialize_at(int idx) const override
     {
-        std::vector<std::string> vv;
-        for (size_t idx = 0;idx < this->m_values.size(); ++idx) {
-            std::ostringstream ss;
-            this->serialize_single_value(ss, this->m_values[idx], this->is_enabled(idx));
-            vv.push_back(ss.str());
-        }
-        return vv;
+        assert(idx >=0  && idx < size());
+        std::ostringstream ss;
+        this->serialize_single_value(ss, this->m_values[idx], this->m_enabled[idx]);
+        return ss.str();
     }
 
     ConfigHelpers::DeserializationResult deserialize_with_substitutions(const std::string &str, bool append, ConfigHelpers::DeserializationSubstitution substitution)
@@ -2519,14 +2199,10 @@ public:
                 enabled = false;
                 item_str = item_str.substr(1);
                 boost::trim(item_str);
+                assert(this->can_be_disabled());
             }
         	unsigned char new_value = 0;
-        	if (item_str == NIL_STR_VALUE) {
-        		if (NULLABLE)
-                    new_value = NIL_VALUE();
-        		else
-                    throw ConfigurationError("Deserializing nil into a non-nullable object");
-        	} else if (item_str == "1") {
+            if (item_str == "1") {
         		new_value = true;
         	} else if (item_str == "0") {
         		new_value = false;
@@ -2550,24 +2226,17 @@ public:
 
 protected:
     void serialize_single_value(std::ostringstream &ss, const unsigned char v, bool enabled) const {
-        if (!enabled)
+        if (!enabled) {
             ss << "!";
-        if (v == NIL_VALUE()) {
-            if (NULLABLE)
-                ss << NIL_STR_VALUE;
-            else
-                throw ConfigurationError("Serializing NaN");
-        } else
-            ss << (v ? "1" : "0");
+            assert(this->can_be_disabled());
+        }
+        ss << (v ? "1" : "0");
     }
 
 private:
 	friend class cereal::access;
 	template<class Archive> void serialize(Archive &ar) { ar(cereal::base_class<ConfigOptionVector<unsigned char>>(this)); }
 };
-
-using ConfigOptionBools    	    = ConfigOptionBoolsTempl<false>;
-using ConfigOptionBoolsNullable = ConfigOptionBoolsTempl<true>;
 
 // Map from an enum integer value to an enum name.
 typedef std::vector<std::string>  t_config_enum_names;
@@ -2840,18 +2509,14 @@ public:
 	t_config_option_key 				opt_key;
     // What type? bool, int, string etc.
     ConfigOptionType                    type            = coNone;
-	// If a type is nullable, then it accepts a "nil" value (scalar) or "nil" values (vector).
-	bool								nullable		= false;
+	// If a type can be disabled (beforeit was nullable be that was a whole circus to make it works and it's dumb concept for "is enbaled": a flag is better)
+	bool								can_be_disabled = false;
+    // if a setting can be disabled, and is enabled, it won't be serialized, or kept.
+	bool								is_optional = false;
     // Default value of this option. The default value object is owned by ConfigDef, it is released in its destructor.
     Slic3r::clonable_ptr<const ConfigOption> default_value;
-    void 								set_default_value(const ConfigOption* ptr) {
-        assert(!ptr->is_vector());
-        this->default_value = Slic3r::clonable_ptr<const ConfigOption>(ptr);
-    }
-    void 								set_default_value(ConfigOptionVectorBase* ptr) {
-        ptr->set_is_extruder_size(this->is_vector_extruder);
-        this->default_value = Slic3r::clonable_ptr<const ConfigOption>(ptr);
-    }
+    void 								set_default_value(ConfigOption* ptr);
+    void 								set_default_value(ConfigOptionVectorBase* ptr);
     template<typename T> const T* 		get_default_value() const { return static_cast<const T*>(this->default_value.get()); }
 
     // Create an empty option to be used as a base for deserialization of DynamicConfig.
@@ -2862,76 +2527,56 @@ public:
     bool                                is_scalar()     const { return (int(this->type) & int(coVectorType)) == 0; }
 
     template<class Archive> ConfigOption* load_option_from_archive(Archive &archive) const {
-        if (this->nullable) {
-            switch (this->type) {
-            case coFloat:           { auto opt = new ConfigOptionFloatNullable();   archive(*opt); return opt; }
-            case coInt:             { auto opt = new ConfigOptionIntNullable();	    archive(*opt); return opt; }
-            case coFloats:          { auto opt = new ConfigOptionFloatsNullable();  archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-            case coInts:            { auto opt = new ConfigOptionIntsNullable();    archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-            case coPercents:        { auto opt = new ConfigOptionPercentsNullable();archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-            case coFloatsOrPercents:{ auto opt = new ConfigOptionFloatsOrPercentsNullable();archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-            case coBools:           { auto opt = new ConfigOptionBoolsNullable();   archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-		    default:                throw ConfigurationError(std::string("ConfigOptionDef::load_option_from_archive(): Unknown nullable option type for option ") + this->opt_key);
-		    }
-    	} else {
-		    switch (this->type) {
-            case coFloat:           { auto opt = new ConfigOptionFloat();           archive(*opt); return opt; }
-            case coFloats:          { auto opt = new ConfigOptionFloats();          archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-            case coInt:             { auto opt = new ConfigOptionInt();             archive(*opt); return opt; }
-            case coInts:            { auto opt = new ConfigOptionInts();            archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-            case coString:          { auto opt = new ConfigOptionString();          archive(*opt); return opt; }
-            case coStrings:         { auto opt = new ConfigOptionStrings();         archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-            case coPercent:         { auto opt = new ConfigOptionPercent();         archive(*opt); return opt; }
-            case coPercents:        { auto opt = new ConfigOptionPercents();        archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-            case coFloatOrPercent:  { auto opt = new ConfigOptionFloatOrPercent();  archive(*opt); return opt; }
-            case coFloatsOrPercents:{ auto opt = new ConfigOptionFloatsOrPercents();archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-            case coPoint:           { auto opt = new ConfigOptionPoint();           archive(*opt); return opt; }
-            case coPoints:          { auto opt = new ConfigOptionPoints();          archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-            case coPoint3:          { auto opt = new ConfigOptionPoint3();          archive(*opt); return opt; }
-            case coGraph:           { auto opt = new ConfigOptionGraph();           archive(*opt); return opt; }
-            case coGraphs:          { auto opt = new ConfigOptionGraphs();          archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-            case coBool:            { auto opt = new ConfigOptionBool();            archive(*opt); return opt; }
-            case coBools:           { auto opt = new ConfigOptionBools();           archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); return opt; }
-		    case coEnum:            { auto opt = new ConfigOptionEnumGeneric(this->enum_def->m_enum_keys_map); archive(*opt); return opt; }
-		    default:                throw ConfigurationError(std::string("ConfigOptionDef::load_option_from_archive(): Unknown option type for option ") + this->opt_key);
-		    }
+        ConfigOption* option;
+		switch (this->type) {
+        case coFloat:           { auto opt = new ConfigOptionFloat();           archive(*opt);
+            assert(this->can_be_disabled == opt->can_be_disabled());
+            if (this->can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coFloats:          { auto opt = new ConfigOptionFloats();          archive(*opt);
+            assert(this->can_be_disabled == opt->can_be_disabled());
+            assert(this->is_vector_extruder == opt->is_extruder_size());
+            opt->set_is_extruder_size(this->is_vector_extruder); if (this->can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coInt:             { auto opt = new ConfigOptionInt();             archive(*opt); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coInts:            { auto opt = new ConfigOptionInts();            archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coString:          { auto opt = new ConfigOptionString();          archive(*opt); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coStrings:         { auto opt = new ConfigOptionStrings();         archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coPercent:         { auto opt = new ConfigOptionPercent();         archive(*opt); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coPercents:        { auto opt = new ConfigOptionPercents();        archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coFloatOrPercent:  { auto opt = new ConfigOptionFloatOrPercent();  archive(*opt); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coFloatsOrPercents:{ auto opt = new ConfigOptionFloatsOrPercents();archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coPoint:           { auto opt = new ConfigOptionPoint();           archive(*opt); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coPoints:          { auto opt = new ConfigOptionPoints();          archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coPoint3:          { auto opt = new ConfigOptionPoint3();          archive(*opt); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coGraph:           { auto opt = new ConfigOptionGraph();           archive(*opt); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coGraphs:          { auto opt = new ConfigOptionGraphs();          archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coBool:            { auto opt = new ConfigOptionBool();            archive(*opt); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+        case coBools:           { auto opt = new ConfigOptionBools();           archive(*opt); opt->set_is_extruder_size(this->is_vector_extruder); if (can_be_disabled) opt->set_can_be_disabled(); return opt; }
+		case coEnum:            { auto opt = new ConfigOptionEnumGeneric(this->enum_def->m_enum_keys_map); archive(*opt); return opt; }
+		default:                throw ConfigurationError(std::string("ConfigOptionDef::load_option_from_archive(): Unknown option type for option ") + this->opt_key);
 		}
 	}
 
     template<class Archive> ConfigOption* save_option_to_archive(Archive &archive, const ConfigOption *opt) const {
-    	if (this->nullable) {
-		    switch (this->type) {
-            case coFloat:           archive(*static_cast<const ConfigOptionFloatNullable*>(opt));  break;
-            case coInt:             archive(*static_cast<const ConfigOptionIntNullable*>(opt));  break;
-		    case coFloats:          archive(*static_cast<const ConfigOptionFloatsNullable*>(opt));  break;
-		    case coInts:            archive(*static_cast<const ConfigOptionIntsNullable*>(opt));    break;
-		    case coPercents:        archive(*static_cast<const ConfigOptionPercentsNullable*>(opt));break;
-		    case coFloatsOrPercents:archive(*static_cast<const ConfigOptionFloatsOrPercentsNullable*>(opt));break;
-		    case coBools:           archive(*static_cast<const ConfigOptionBoolsNullable*>(opt)); 	break;
-		    default:                throw ConfigurationError(std::string("ConfigOptionDef::save_option_to_archive(): Unknown nullable option type for option ") + this->opt_key);
-		    }
-		} else {
-		    switch (this->type) {
-		    case coFloat:           archive(*static_cast<const ConfigOptionFloat*>(opt));  			break;
-		    case coFloats:          archive(*static_cast<const ConfigOptionFloats*>(opt)); 			break;
-		    case coInt:             archive(*static_cast<const ConfigOptionInt*>(opt)); 	 		break;
-		    case coInts:            archive(*static_cast<const ConfigOptionInts*>(opt)); 	 		break;
-		    case coString:          archive(*static_cast<const ConfigOptionString*>(opt)); 			break;
-		    case coStrings:         archive(*static_cast<const ConfigOptionStrings*>(opt)); 		break;
-		    case coPercent:         archive(*static_cast<const ConfigOptionPercent*>(opt)); 		break;
-		    case coPercents:        archive(*static_cast<const ConfigOptionPercents*>(opt)); 		break;
-		    case coFloatOrPercent:  archive(*static_cast<const ConfigOptionFloatOrPercent*>(opt));	break;
-		    case coFloatsOrPercents:archive(*static_cast<const ConfigOptionFloatsOrPercents*>(opt));break;
-		    case coPoint:           archive(*static_cast<const ConfigOptionPoint*>(opt)); 			break;
-		    case coPoints:          archive(*static_cast<const ConfigOptionPoints*>(opt)); 			break;
-		    case coPoint3:          archive(*static_cast<const ConfigOptionPoint3*>(opt)); 			break;
-		    case coGraph:           archive(*static_cast<const ConfigOptionGraph*>(opt)); 			break;
-		    case coGraphs:          archive(*static_cast<const ConfigOptionGraphs*>(opt)); 			break;
-		    case coBool:            archive(*static_cast<const ConfigOptionBool*>(opt)); 			break;
-		    case coBools:           archive(*static_cast<const ConfigOptionBools*>(opt)); 			break;
-		    case coEnum:            archive(*static_cast<const ConfigOptionEnumGeneric*>(opt)); 	break;
-		    default:                throw ConfigurationError(std::string("ConfigOptionDef::save_option_to_archive(): Unknown option type for option ") + this->opt_key);
-		    }
+		switch (this->type) {
+		case coFloat:           archive(*static_cast<const ConfigOptionFloat*>(opt));  			break;
+		case coFloats:          archive(*static_cast<const ConfigOptionFloats*>(opt)); 			break;
+		case coInt:             archive(*static_cast<const ConfigOptionInt*>(opt)); 	 		break;
+		case coInts:            archive(*static_cast<const ConfigOptionInts*>(opt)); 	 		break;
+		case coString:          archive(*static_cast<const ConfigOptionString*>(opt)); 			break;
+		case coStrings:         archive(*static_cast<const ConfigOptionStrings*>(opt)); 		break;
+		case coPercent:         archive(*static_cast<const ConfigOptionPercent*>(opt)); 		break;
+		case coPercents:        archive(*static_cast<const ConfigOptionPercents*>(opt)); 		break;
+		case coFloatOrPercent:  archive(*static_cast<const ConfigOptionFloatOrPercent*>(opt));	break;
+		case coFloatsOrPercents:archive(*static_cast<const ConfigOptionFloatsOrPercents*>(opt));break;
+		case coPoint:           archive(*static_cast<const ConfigOptionPoint*>(opt)); 			break;
+		case coPoints:          archive(*static_cast<const ConfigOptionPoints*>(opt)); 			break;
+		case coPoint3:          archive(*static_cast<const ConfigOptionPoint3*>(opt)); 			break;
+		case coGraph:           archive(*static_cast<const ConfigOptionGraph*>(opt)); 			break;
+		case coGraphs:          archive(*static_cast<const ConfigOptionGraphs*>(opt)); 			break;
+		case coBool:            archive(*static_cast<const ConfigOptionBool*>(opt)); 			break;
+		case coBools:           archive(*static_cast<const ConfigOptionBools*>(opt)); 			break;
+		case coEnum:            archive(*static_cast<const ConfigOptionEnumGeneric*>(opt)); 	break;
+		default:                throw ConfigurationError(std::string("ConfigOptionDef::save_option_to_archive(): Unknown option type for option ") + this->opt_key);
 		}
 		// Make the compiler happy, shut up the warnings.
 		return nullptr;
@@ -3147,7 +2792,6 @@ public:
 
 protected:
     ConfigOptionDef*        add(const t_config_option_key &opt_key, ConfigOptionType type);
-    ConfigOptionDef*        add_nullable(const t_config_option_key &opt_key, ConfigOptionType type);
     // Finalize open / close enums, validate everything.
     void                    finalize();
 };
@@ -3395,8 +3039,8 @@ public:
     ConfigSubstitutions load(const boost::property_tree::ptree &tree, ForwardCompatibilitySubstitutionRule compatibility_rule);
     void save(const std::string &file, bool to_prusa = false) const;
 
-	// Set all the nullable values to nils.
-    void null_nullables();
+    // Disable all the optional settings.
+    void disable_optionals();
 
     static std::map<t_config_option_key, std::string> load_gcode_string_legacy(const char* str);
     static size_t load_from_gcode_string_legacy(ConfigBase& config, const char* str, ConfigSubstitutionContext& substitutions);
@@ -3507,8 +3151,8 @@ public:
         return true;
     }
 
-    // Remove options with all nil values, those are optional and it does not help to hold them.
-    size_t remove_nil_options();
+    // Remove disabled optional options, it does not help to hold them.
+    size_t remove_optional_disabled_options();
 
     // Allow DynamicConfig to be instantiated on ints own without a definition.
     // If the definition is not defined, the method requiring the definition will throw NoDefinitionException.

--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -3016,6 +3016,7 @@ public:
     bool      get_bool(const t_config_option_key &opt_key, size_t idx = 0) const                 {return this->option(opt_key)->get_bool(idx);}
     int32_t   get_int(const t_config_option_key &opt_key, size_t idx = 0) const                  {return this->option(opt_key)->get_int(idx);}
     double    get_float(const t_config_option_key &opt_key, size_t idx = 0) const                {return this->option(opt_key)->get_float(idx);}
+    bool      is_enabled(const t_config_option_key &opt_key, size_t idx = 0) const                {return this->option(opt_key)->is_enabled(idx);}
 
     // In ConfigManipulation::toggle_print_fff_options, it is called on option with type ConfigOptionEnumGeneric* and also ConfigOptionEnum*.
     // Thus the virtual method getInt() is used to retrieve the enum value.

--- a/src/libslic3r/Extruder.cpp
+++ b/src/libslic3r/Extruder.cpp
@@ -249,7 +249,7 @@ double Extruder::retract_before_wipe() const
 
 double Extruder::retract_length() const
 {
-    assert(!m_config->retract_length.is_nil());
+    assert(m_config->retract_length.is_enabled());
     assert(m_config->retract_length.get_at(m_id) < std::numeric_limits<int32_t>::max());
     assert(m_config->retract_length.get_at(m_id) > -std::numeric_limits<int32_t>::max());
     assert(m_config->retract_length.size() > m_id);
@@ -258,7 +258,7 @@ double Extruder::retract_length() const
 
 double Extruder::retract_lift() const
 {
-    assert(!m_config->retract_lift.is_nil());
+    assert(m_config->retract_lift.is_enabled());
     assert(m_config->retract_lift.get_at(m_id) < std::numeric_limits<int32_t>::max());
     assert(m_config->retract_lift.get_at(m_id) > -std::numeric_limits<int32_t>::max());
     assert(m_config->retract_lift.size() > m_id);
@@ -278,7 +278,7 @@ int Extruder::deretract_speed() const
 
 double Extruder::retract_restart_extra() const
 {
-    assert(!m_config->retract_restart_extra.is_nil());
+    assert(m_config->retract_restart_extra.is_enabled());
     assert(m_config->retract_restart_extra.get_at(m_id) < std::numeric_limits<int32_t>::max());
     assert(m_config->retract_restart_extra.get_at(m_id) > -std::numeric_limits<int32_t>::max());
     assert(m_config->retract_restart_extra.size() > m_id);
@@ -292,7 +292,7 @@ double Extruder::retract_length_toolchange() const
 
 double Extruder::retract_restart_extra_toolchange() const
 {
-    assert(!m_config->retract_restart_extra_toolchange.is_nil());
+    assert(m_config->retract_restart_extra_toolchange.is_enabled());
     assert(m_config->retract_restart_extra_toolchange.get_at(m_id) < std::numeric_limits<int32_t>::max());
     assert(m_config->retract_restart_extra_toolchange.get_at(m_id) > -std::numeric_limits<int32_t>::max());
     assert(m_config->retract_restart_extra_toolchange.size() > m_id);

--- a/src/libslic3r/Format/BBConfig.cpp
+++ b/src/libslic3r/Format/BBConfig.cpp
@@ -597,8 +597,8 @@ void very_complicated_convert(ConfigSubstitutionContext &unconverted_config, Con
             double overhangs_max_slope = std::tan(make_overhang_printable_angle) * layer_height;
             conf_to_read_and_update.set_deserialize("overhangs_max_slope",
                                                     Slic3r::to_string_nozero(overhangs_max_slope, 3));
-            conf_to_read_and_update.set_deserialize("overhangs_bridge_threshold", "-1");
-            conf_to_read_and_update.set_deserialize("overhangs_bridge_upper_layers", "-1");
+            conf_to_read_and_update.set_deserialize("overhangs_bridge_threshold", "!0");
+            conf_to_read_and_update.set_deserialize("overhangs_bridge_upper_layers", "!0");
             unconverted_config.erase("make_overhang_printable");
             unconverted_config.erase("make_overhang_printable_angle");
         } else {

--- a/src/libslic3r/Format/CWS.cpp
+++ b/src/libslic3r/Format/CWS.cpp
@@ -101,7 +101,7 @@ void fill_slicerconf(ConfMap &m, const SLAPrint &print)
     
     auto &cfg = print.full_print_config();
     for (const std::string &key : cfg.keys())
-        if (! is_banned(key) && ! cfg.option(key)->is_nil())
+        if (!is_banned(key) && (cfg.option(key)->is_enabled() || !cfg.get_option_def(key)->is_optional))
             m[key] = cfg.opt_serialize(key);
     
 }

--- a/src/libslic3r/Format/SL1.cpp
+++ b/src/libslic3r/Format/SL1.cpp
@@ -126,7 +126,7 @@ void fill_slicerconf(ConfMap &m, const SLAPrint &print)
     
     auto &cfg = print.full_print_config();
     for (const std::string &key : cfg.keys())
-        if (! is_banned(key) && ! cfg.option(key)->is_nil())
+        if (!is_banned(key) && (cfg.option(key)->is_enabled() || !cfg.get_option_def(key)->is_optional))
             m[key] = cfg.opt_serialize(key);
     
 }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -179,8 +179,8 @@ namespace Slic3r {
         //        gcode += gcodegen.writer().travel_to_xy(unscale(standby_point), 0.0, "move to standby position");
         //}
         unsigned int extruder_id = gcodegen.writer().tool()->id();
-        const ConfigOptionIntsNullable& filament_idle_temp = gcodegen.config().idle_temperature;
-        if (filament_idle_temp.is_nil(extruder_id)) {
+        const ConfigOptionInts& filament_idle_temp = gcodegen.config().idle_temperature;
+        if (!filament_idle_temp.is_enabled(extruder_id)) {
             // There is no idle temperature defined in filament settings.
             // Use the delta value from print config.
             if (gcodegen.config().standby_temperature_delta.value != 0 && gcodegen.writer().tool_is_extruder() && this->_get_temp(gcodegen) > 0) {
@@ -2742,7 +2742,7 @@ void GCodeGenerator::_print_first_layer_extruder_temperatures(std::string &out, 
                 if (temp == 0)
                     temp = print.config().temperature.get_at(tool.id());
                 if (print.config().ooze_prevention.value && tool.id() != first_printing_extruder_id)
-                    if (print.config().idle_temperature.is_nil(tool.id()))
+                    if (!print.config().idle_temperature.is_enabled(tool.id()))
                         temp += print.config().standby_temperature_delta.value;
                     else
                         temp = print.config().idle_temperature.get_at(tool.id());
@@ -3881,7 +3881,7 @@ void GCodeGenerator::encode_full_config(const Print& print, std::vector<std::pai
     };
     config.reserve(config.size() + cfg.keys().size());
     for (const std::string& key : cfg.keys()) {
-        if (!is_banned(key) && !cfg.option(key)->is_nil())
+        if (!is_banned(key) && (cfg.option(key)->is_enabled() || !cfg.get_option_def(key)->is_optional))
             config.emplace_back(key, cfg.opt_serialize(key));
     }
     config.shrink_to_fit();

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -2760,23 +2760,26 @@ void PerimeterGenerator::process(// Input:
 
         // detect how many perimeters must be generated for this island
         int nb_loop_contour = params.config.perimeters;
+        assert(nb_loop_contour >= 0);
+        assert(params.config.perimeters.is_enabled());
         if (nb_loop_contour > 0)
             nb_loop_contour += extra_odd_perimeter + surface.extra_perimeters;
-        int nb_loop_holes = params.config.perimeters_hole;
-        if (nb_loop_holes > 0)
+        assert(nb_loop_contour >= 0);
+        int nb_loop_holes = params.config.perimeters_hole.value;
+        assert(nb_loop_holes >= 0);
+        if (params.config.perimeters_hole.is_enabled() && nb_loop_holes > 0)
             nb_loop_holes += extra_odd_perimeter + surface.extra_perimeters;
+        assert(nb_loop_holes >= 0);
         
-        if (nb_loop_contour < 0)
-            nb_loop_contour = std::max(0, nb_loop_holes);
-        if (nb_loop_holes < 0)
+        if (!params.config.perimeters_hole.is_enabled())
             nb_loop_holes = std::max(0, nb_loop_contour);
 
-            if (params.print_config.spiral_vase) {
-                if (params.layer->id() >= params.config.bottom_solid_layers) {
-                    nb_loop_contour = 1;
-                    nb_loop_holes = 0;
-                }
+        if (params.print_config.spiral_vase) {
+            if (params.layer->id() >= params.config.bottom_solid_layers) {
+                nb_loop_contour = 1;
+                nb_loop_holes = 0;
             }
+        }
 
         if ((params.layer->id() == 0 && params.config.only_one_perimeter_first_layer) ||
             (params.config.only_one_perimeter_top && this->upper_slices == NULL)) {

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1315,7 +1315,9 @@ ExternalPreset PresetCollection::load_external_preset(
                 this->update_dirty();
                 // Don't save the newly loaded project as a "saved into project" state.
                 //update_saved_preset_from_current_preset();
-                assert(this->get_edited_preset().is_dirty);
+                
+                // the get_edited_preset can be 'not dirty' if it's exactly the same as a saved preset.
+                //assert(this->get_edited_preset().is_dirty);
             }
             return ExternalPreset(&(*it), this->get_edited_preset().is_dirty, is_installed);
         }

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -67,14 +67,14 @@ PresetBundle::PresetBundle() :
     this->filaments.default_preset().config.option<ConfigOptionStrings>("filament_settings_id", true)->set({""});
     this->filaments.default_preset().compatible_printers_condition();
     this->filaments.default_preset().inherits();
-	// Set all the nullable values to nils.
-	this->filaments.default_preset().config.null_nullables();
+	// Disable all the optionals values.
+	this->filaments.default_preset().config.disable_optionals();
 
     this->sla_materials.default_preset().config.optptr("sla_material_settings_id", true);
     this->sla_materials.default_preset().compatible_printers_condition();
     this->sla_materials.default_preset().inherits();
-    // Set all the nullable values to nils.
-    this->sla_materials.default_preset().config.null_nullables();
+	// Disable all the optionals values.
+    this->sla_materials.default_preset().config.disable_optionals();
 
     this->sla_prints.default_preset().config.optptr("sla_print_settings_id", true);
     this->sla_prints.default_preset().config.opt_string("output_filename_format", true) = "[input_filename_base].sl1";

--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -221,12 +221,11 @@ static t_config_option_keys print_config_diffs(
             //FIXME This may happen when executing some test cases.
             continue;
         const ConfigOption *opt_new_filament = std::binary_search(extruder_retract_keys.begin(), extruder_retract_keys.end(), opt_key) ? new_full_config.option(filament_prefix + opt_key) : nullptr;
-        if (opt_new_filament != nullptr && ! opt_new_filament->is_nil()) {
+        if (opt_new_filament != nullptr) {
             // An extruder retract override is available at some of the filament presets.
-            bool overriden = opt_new->overriden_by(opt_new_filament);
-            if (overriden || *opt_old != *opt_new) {
+            if (*opt_old != *opt_new || opt_new->overriden_by(opt_new_filament)) {
                 auto opt_copy = opt_new->clone();
-                opt_copy->apply_override(opt_new_filament);
+                bool overriden = opt_copy->apply_override(opt_new_filament);
                 bool changed = *opt_old != *opt_copy;
                 if (changed)
                     print_diff.emplace_back(opt_key);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -825,7 +825,6 @@ void PrintConfigDef::init_fff_params()
     def->min = -1;
     def->max = 100;
     def->mode = comAdvancedE | comSuSi;
-    def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionEnum<BridgeType>{ BridgeType::btFromNozzle });
 
     def = this->add("bridge_flow_ratio", coPercent);
@@ -3654,7 +3653,6 @@ void PrintConfigDef::init_fff_params()
     def->sidetext = L("mm");
     def->min = 0;
     def->mode = comExpert | comSuSi;
-    def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionFloat(0));
 
     def = this->add("machine_limits_usage", coEnum);
@@ -4355,7 +4353,6 @@ void PrintConfigDef::init_fff_params()
     def->sidetext = L("mm or %");
     def->aliases = { "perimeters_extrusion_width" };
     def->ratio_over = "nozzle_diameter";
-    def->is_vector_extruder = true;
     def->min = 0;
     def->max = 1000;
     def->max_literal = { 10, true };
@@ -7026,37 +7023,43 @@ void PrintConfigDef::init_fff_params()
         "seam_gap"}) {
         auto it_opt = options.find(opt_key);
         assert(it_opt != options.end());
-        def = this->add_nullable(std::string("filament_") + opt_key, it_opt->second.type);
+        def = this->add(std::string("filament_") + opt_key, it_opt->second.type);
+        def->can_be_disabled = true;
+        def->is_optional = true;
         def->label      = it_opt->second.label;
         def->full_label = it_opt->second.full_label;
         def->tooltip    = it_opt->second.tooltip;
         def->sidetext   = it_opt->second.sidetext;
         def->mode       = it_opt->second.mode;
         // create default value with the default value is taken from the default value of the config.
-        // put a nil value as first entry.
+        // put a disbaled value as first entry.
         switch (def->type) {
         case coBools: {
-            ConfigOptionBoolsNullable* opt = new ConfigOptionBoolsNullable(it_opt->second.default_value.get()->get_bool());
-            opt->set_at(ConfigOptionBoolsNullable::NIL_VALUE(), 0);
+            ConfigOptionBools* opt = new ConfigOptionBools(it_opt->second.default_value.get()->get_bool());
+            opt->set_can_be_disabled();
+            opt->set_enabled(false);
             def->set_default_value(opt);
             break;
         }
         case coFloats: {
-            ConfigOptionFloatsNullable *opt = new ConfigOptionFloatsNullable(it_opt->second.default_value.get()->get_float());
-            opt->set_any(ConfigOptionFloatNullable::create_any_nil(), 0);
+            ConfigOptionFloats *opt = new ConfigOptionFloats(it_opt->second.default_value.get()->get_float());
+            opt->set_can_be_disabled();
+            opt->set_enabled(false);
             def->set_default_value(opt);
             break;
         }
         case coPercents: {
-            ConfigOptionPercentsNullable *opt = new ConfigOptionPercentsNullable(it_opt->second.default_value.get()->get_float());
-            opt->set_any(ConfigOptionFloatNullable::create_any_nil(), 0);
+            ConfigOptionPercents *opt = new ConfigOptionPercents(it_opt->second.default_value.get()->get_float());
+            opt->set_can_be_disabled();
+            opt->set_enabled(false);
             def->set_default_value(opt);
             break;
         }
         case coFloatsOrPercents: {
-            ConfigOptionFloatsOrPercentsNullable*opt = new ConfigOptionFloatsOrPercentsNullable(
+            ConfigOptionFloatsOrPercents*opt = new ConfigOptionFloatsOrPercents(
                 static_cast<const ConfigOptionFloatsOrPercents*>(it_opt->second.default_value.get())->get_at(0));
-            opt->set_any(ConfigOptionFloatsOrPercents::create_any_nil(), 0);
+            opt->set_can_be_disabled();
+            opt->set_enabled(false);
             def->set_default_value(opt);
             break;
         }
@@ -7654,15 +7657,16 @@ void PrintConfigDef::init_sla_params()
     def->mode = comSimpleAE | comPrusa;
     def->set_default_value(new ConfigOptionFloat(0.3));
 
-    def = this->add_nullable("idle_temperature", coInts);
+    def = this->add("idle_temperature", coInts);
     def->label = L("Idle temperature");
     def->tooltip = L("Nozzle temperature when the tool is currently not used in multi-tool setups."
-                     "This is only used when 'Ooze prevention' is active in Print Settings.");
+                     "\nThis is only used when 'Ooze prevention' is active in Print Settings.");
     def->sidetext = L("°C");
     def->min = 0;
     def->max = max_temp;
+    def->can_be_disabled = true;
     def->mode = comSimpleAE | comPrusa;
-    def->set_default_value(new ConfigOptionIntsNullable { ConfigOptionIntNullable::nil_value() });
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts{30})->set_can_be_disabled()->set_enabled(false));
 
     def = this->add("bottle_volume", coFloat);
     def->label = L("Bottle volume");
@@ -8087,7 +8091,9 @@ void PrintConfigDef::init_sla_params()
         }) {
         auto it_opt = options.find(opt_key);
         assert(it_opt != options.end());
-        def = this->add_nullable(std::string("material_ow_") + opt_key, it_opt->second.type);
+        def = this->add(std::string("material_ow_") + opt_key, it_opt->second.type);
+        def->can_be_disabled = true;
+        def->is_optional = true;
         def->label = it_opt->second.label;
         def->full_label = it_opt->second.full_label;
         def->tooltip = it_opt->second.tooltip;
@@ -8095,11 +8101,7 @@ void PrintConfigDef::init_sla_params()
         def->min  = it_opt->second.min;
         def->max  = it_opt->second.max;
         def->mode = it_opt->second.mode;
-        switch (def->type) {
-        case coFloat: def->set_default_value(new ConfigOptionFloatNullable{ it_opt->second.default_value->get_float() }); break;
-        case coInt:   def->set_default_value(new ConfigOptionIntNullable{ it_opt->second.default_value->get_int() }); break;
-        default: assert(false);
-        }
+        def->set_default_value(it_opt->second.default_value->clone());
     }
 }
 
@@ -9550,7 +9552,7 @@ void DynamicPrintConfig::normalize_fdm()
             auto* opt = this->opt<ConfigOptionBools>("retract_layer_change", true);
             opt->set(std::vector<uint8_t>(opt->size(), false));  // set all values to false
             // Disable retract on layer change also for filament overrides.
-            auto* opt_n = this->opt<ConfigOptionBoolsNullable>("filament_retract_layer_change", true);
+            auto* opt_n = this->opt<ConfigOptionBools>("filament_retract_layer_change", true);
             opt_n->set(std::vector<uint8_t>(opt_n->size(), false));  // Set all values to false.
         }
         {
@@ -10204,8 +10206,8 @@ std::string validate(const FullPrintConfig& cfg)
         const ConfigOptionDef   *optdef = print_config_def.get(opt_key);
         assert(optdef != nullptr);
 
-        if (opt->nullable() && opt->is_nil()) {
-            // Do not check nil values
+        if (!opt->is_enabled()) {
+            // Do not check disabled values
             continue;
         }
 
@@ -10229,7 +10231,7 @@ std::string validate(const FullPrintConfig& cfg)
         {
             const auto* vec = static_cast<const ConfigOptionVector<double>*>(opt);
             for (size_t i = 0; i < vec->size(); ++i) {
-                if (vec->is_nil(i))
+                if (!vec->is_enabled(i))
                     continue;
                 double v = vec->get_at(i);
                 if (v < optdef->min || v > optdef->max) {
@@ -10243,7 +10245,7 @@ std::string validate(const FullPrintConfig& cfg)
         {
             const auto* vec = static_cast<const ConfigOptionVector<FloatOrPercent>*>(opt);
             for (size_t i = 0; i < vec->size(); ++i) {
-                if (vec->is_nil(i))
+                if (!vec->is_enabled(i))
                     continue;
                 const FloatOrPercent &v = vec->get_at(i);
                 if (v.value < optdef->min || v.value > optdef->max) {
@@ -10263,7 +10265,7 @@ std::string validate(const FullPrintConfig& cfg)
         {
             const auto* vec = static_cast<const ConfigOptionVector<int32_t>*>(opt);
             for (size_t i = 0; i < vec->size(); ++i) {
-                if (vec->is_nil(i))
+                if (!vec->is_enabled(i))
                     continue;
                 int v = vec->get_at(i);
                 if (v < optdef->min || v > optdef->max) {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -387,6 +387,14 @@ namespace {
     const int max_temp = 1500;
 };
 
+ConfigOption *disable_defaultoption(ConfigOption *option) {
+    return option->set_can_be_disabled()->set_enabled(false);
+}
+
+ConfigOptionVectorBase *disable_defaultoption(ConfigOptionVectorBase *option) {
+    return (ConfigOptionVectorBase *)option->set_can_be_disabled()->set_enabled(false);
+}
+
 PrintConfigDef::PrintConfigDef()
 {
     this->init_common_params();
@@ -824,8 +832,6 @@ void PrintConfigDef::init_fff_params()
         { "height", L("Layer height") },
         { "flow", L("Keep current flow") },
     });
-    def->min = -1;
-    def->max = 100;
     def->mode = comAdvancedE | comSuSi;
     def->set_default_value(new ConfigOptionEnum<BridgeType>{ BridgeType::btFromNozzle });
 
@@ -1362,7 +1368,7 @@ void PrintConfigDef::init_fff_params()
     def->max                = 100;
     def->is_vector_extruder = true;
     def->can_be_disabled = true;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts({ 100 })));
     def->aliases = { "min_fan_speed" }; // only if "fan_always_on"
 
     def = this->add("default_print_profile", coString);
@@ -1660,7 +1666,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
     def->can_be_disabled = true;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts({ 100 })));
 
     def = this->add("external_perimeter_overlap", coPercent);
     def->label = L("external perimeter overlap");
@@ -2904,7 +2910,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert | comSuSi;
     def->is_vector_extruder = true;
     def->can_be_disabled = true;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts({ 100 })));
 
     def = this->add("gap_fill_flow_match_perimeter", coPercent);
     def->label = L("Cap with perimeter flow");
@@ -3338,7 +3344,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert | comSuSi;
     def->is_vector_extruder = true;
     def->can_be_disabled = true;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts({ 100 })));
 
     def = this->add("infill_first", coBool);
     def->label = L("Infill before perimeters");
@@ -3436,7 +3442,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
     def->can_be_disabled = true;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts({ 100 })));
     def->aliases = { "bridge_internal_fan_speed" };
 
     def = this->add("internal_bridge_speed", coFloatOrPercent);
@@ -4144,7 +4150,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
     def->can_be_disabled = true;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts({ 100 })));
 
     def = this->add("overhangs_max_slope", coFloatOrPercent);
     def->label = L("Overhangs max slope");
@@ -4164,23 +4170,25 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Bridge max length");
     def->category = OptionCategory::slicing;
     def->tooltip = L("Maximum distance for bridges. If the distance is over that, it will be considered as overhangs for 'overhangs_max_slope'."
-                    "\nSet to -1 to accept all distances."
+                    "\nIf disabled, accept all distances."
                     "\nSet to 0 to ignore bridges.");
     def->sidetext = L("mm");
-    def->min = -1;
+    def->min = 0;
+    def->can_be_disabled = true;
     def->mode = comExpert | comSuSi;
-    def->set_default_value(new ConfigOptionFloat(-1));
+    def->set_default_value(disable_defaultoption(new ConfigOptionFloat(0)));
 
     def = this->add("overhangs_bridge_upper_layers", coInt);
     def->label = L("Consider upper bridges");
     def->category = OptionCategory::slicing;
     def->tooltip = L("Don't put overhangs if the area will filled in next layer by bridges."
-                    "\nSet to -1 to accept all upper layers."
+                    "\nIf disabled, accept all upper layers."
                     "\nSet to 0 to only consider our layer bridges.");
     def->sidetext = L("layers");
-    def->min = -1;
+    def->min = 0;
+    def->can_be_disabled = true;
     def->mode = comExpert | comSuSi;
-    def->set_default_value(new ConfigOptionInt(0));
+    def->set_default_value(new ConfigOptionInt(2));
 
     def = this->add("overhangs_speed", coFloatOrPercent);
     def->label = L("Overhangs");
@@ -4409,7 +4417,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert | comSuSi;
     def->is_vector_extruder = true;
     def->can_be_disabled = true;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts({ 100 })));
 
     def = this->add("perimeter_loop", coBool);
     def->label = L("Perimeters loop");
@@ -4499,15 +4507,16 @@ void PrintConfigDef::init_fff_params()
     def->category = OptionCategory::perimeter;
     def->tooltip = L("This option sets the number of perimeters to have over holes."
                    " Note that if a hole-perimeter fuse with the contour, then it will go around like a contour perimeter.."
-                   "\nSet to -1 to deactivate, then holes will have the same number of perimeters as contour."
+                   "\nIf disabled, holes will have the same number of perimeters as contour."
                    "\nNote that Slic3r may increase this number automatically when it detects "
                    "sloping surfaces which benefit from a higher number of perimeters "
                    "if the Extra Perimeters option is enabled.");
     def->sidetext = L("(minimum).");
-    def->min = -1;
+    def->min = 0;
     def->max = 10000;
+    def->can_be_disabled = true;
     def->mode = comAdvancedE | comSuSi;
-    def->set_default_value(new ConfigOptionInt(-1));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInt(0)));
 
     def = this->add("post_process", coStrings);
     def->label = L("Post-processing scripts");
@@ -5399,7 +5408,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert | comSuSi;
     def->is_vector_extruder = true;
     def->can_be_disabled = true;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts({ 100 })));
 
     def = this->add("solid_infill_speed", coFloatOrPercent);
     def->label = L("Solid");
@@ -5777,7 +5786,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert | comSuSi;
     def->is_vector_extruder = true;
     def->can_be_disabled = true;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts({ 100 })));
 
     def = this->add("support_material_interface_angle", coFloat);
     def->label = L("Pattern angle");
@@ -5813,7 +5822,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
     def->can_be_disabled = true;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts({ 100 })));
 
 
     def = this->add("support_material_interface_contact_loops", coBool);
@@ -5850,20 +5859,20 @@ void PrintConfigDef::init_fff_params()
     def = this->add("support_material_bottom_interface_layers", coInt);
     def->label = L("Bottom interface layers");
     def->category = OptionCategory::support;
-    def->tooltip = L("Number of interface layers to insert between the object(s) and support material. "
-        "Set to -1 to use support_material_interface_layers");
+    def->tooltip = L("Number of interface layers to insert between the object(s) and support material."
+        "\nIf disabled, support_material_interface_layers value is used");
     def->sidetext = L("layers");
-    def->min = -1;
+    def->min = 0;
+    def->can_be_disabled = true;
     def->set_enum_values(ConfigOptionDef::GUIType::i_enum_open, {
     //TRN Print Settings: "Bottom interface layers". Have to be as short as possible
-        { "-1", L("Same as top") },
         { "0", L("0 (off)") },
         { "1", L("1 (light)") },
         { "2", L("2 (default)") },
         { "3", L("3 (heavy)") }
     });
     def->mode = comAdvancedE | comPrusa;
-    def->set_default_value(new ConfigOptionInt(-1));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInt(0)));
 
     def = this->add("support_material_closing_radius", coFloat);
     def->label = L("Closing radius");
@@ -6360,7 +6369,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
     def->can_be_disabled = true;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts({ 100 })));
 
     def = this->add("top_infill_extrusion_width", coFloatOrPercent);
     def->label = L("Top solid infill");
@@ -7680,7 +7689,7 @@ void PrintConfigDef::init_sla_params()
     def->max = max_temp;
     def->can_be_disabled = true;
     def->mode = comSimpleAE | comPrusa;
-    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts{30})->set_can_be_disabled()->set_enabled(false));
+    def->set_default_value(disable_defaultoption(new ConfigOptionInts{30}));
 
     def = this->add("bottle_volume", coFloat);
     def->label = L("Bottle volume");
@@ -8405,6 +8414,13 @@ void PrintConfigDef::handle_legacy(t_config_option_key &opt_key, std::string &va
                 value = "0";
             }
         }
+    }
+
+    if (value == "-1") {
+        if ("overhangs_bridge_threshold" == opt_key) {value = "!0";}
+        if ("overhangs_bridge_upper_layers" == opt_key) {value = "!2";}
+        if ("perimeters_hole" == opt_key) {value = "!0";}
+        if ("support_material_bottom_interface_layers" == opt_key) {value = "!0";}
     }
 
     if (!print_config_def.has(opt_key)) {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -797,13 +797,15 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Bridges fan speed");
     def->category = OptionCategory::cooling;
     def->tooltip = L("This fan speed is enforced during bridges and overhangs. It won't slow down the fan if it's currently running at a higher speed."
-        "\nSet to -1 to disable this override (Bridges will use default fan speed)."
+        "\nSet to 0 to stop the fan."
+        "\nIf disabled, default fan speed will be used."
         "\nCan be disabled by disable_fan_first_layers and increased by low layer time.");
     def->sidetext = L("%");
-    def->min = -1;
+    def->min = 0;
     def->max = 100;
     def->mode = comAdvancedE | comPrusa;
     def->is_vector_extruder = true;
+    def->can_be_disabled = true;
     def->set_default_value(new ConfigOptionInts{ 100 });
 
     def = this->add("bridge_type", coEnum);
@@ -1354,12 +1356,13 @@ void PrintConfigDef::init_fff_params()
     def->tooltip  = L(
         "Default speed for the fan, to set the speed for features where there is no fan control. Useful for PLA and other low-temp filament."
         "\nSet 0 to disable the fan by default. Useful for ABS and other high-temp filaments."
-        "\nSet -1 to disable. if disabled, the beahavior isn't defined yet. The goal is to avoid adding fan speed commands.");
+        "\nIf disabled, no fan speed command will be emmited when possible (if a feature set a speed, it won't be reverted).");
     def->mode               = comSimpleAE | comSuSi;
-    def->min                = -1;
+    def->min                = 0;
     def->max                = 100;
     def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionInts({-1}));
+    def->can_be_disabled = true;
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
     def->aliases = { "min_fan_speed" }; // only if "fan_always_on"
 
     def = this->add("default_print_profile", coString);
@@ -1646,17 +1649,18 @@ void PrintConfigDef::init_fff_params()
     def = this->add("external_perimeter_fan_speed", coInts);
     def->label = L("External perimeter fan speed");
     def->tooltip = L("When set to a non-zero value this fan speed is used only for external perimeters (visible ones) and thin walls."
-                    "\nSet to 1 to disable the fan."
-                    "\nSet to -1 to use the normal fan speed on external perimeters."
-                    "External perimeters can benefit from higher fan speed to improve surface finish, "
+                    "\nSet to 0 to stop the fan."
+                    "\nIf disabled, the default fan speed will be used."
+                    "\nExternal perimeters can benefit from higher fan speed to improve surface finish, "
                     "while internal perimeters, infill, etc. benefit from lower fan speed to improve layer adhesion."
                     "\nCan be disabled by disable_fan_first_layers, slowed down by full_fan_speed_layer and increased by low layer time.");
     def->sidetext = L("%");
-    def->min = -1;
+    def->min = 0;
     def->max = 100;
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionInts { -1 });
+    def->can_be_disabled = true;
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
 
     def = this->add("external_perimeter_overlap", coPercent);
     def->label = L("external perimeter overlap");
@@ -2891,15 +2895,16 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Gap fill fan speed");
     def->category = OptionCategory::cooling;
     def->tooltip = L("This fan speed is enforced during all gap fill Perimeter moves"
-        "\nSet to 1 to disable fan."
-        "\nSet to -1 to disable this override (Gap Fill will use default fan speed)."
+        "\nSet to 0 to stop the fan."
+        "\nIf disabled, default fan speed will be used."
         "\nCan be disabled by disable_fan_first_layers, slowed down by full_fan_speed_layer and increased by low layer time.");
     def->sidetext = L("%");
-    def->min = -1;
+    def->min = 0;
     def->max = 100;
     def->mode = comExpert | comSuSi;
     def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionInts{ -1 });
+    def->can_be_disabled = true;
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
 
     def = this->add("gap_fill_flow_match_perimeter", coPercent);
     def->label = L("Cap with perimeter flow");
@@ -3324,15 +3329,16 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Internal Infill fan speed");
     def->category = OptionCategory::cooling;
     def->tooltip = L("This fan speed is enforced during all Internal Infill moves"
-        "\nSet to 1 to disable fan."
-        "\nSet to -1 to disable this override (Internal Infill will use default fan speed)."
+        "\nSet to 0 to stop the fan."
+        "\nIf disabled, default fan speed will be used."
         "\nCan be disabled by disable_fan_first_layers, slowed down by full_fan_speed_layer and increased by low layer time.");
     def->sidetext = L("%");
-    def->min = -1;
+    def->min = 0;
     def->max = 100;
     def->mode = comExpert | comSuSi;
     def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionInts{ -1 });
+    def->can_be_disabled = true;
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
 
     def = this->add("infill_first", coBool);
     def->label = L("Infill before perimeters");
@@ -3421,14 +3427,16 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Infill bridges fan speed");
     def->category = OptionCategory::cooling;
     def->tooltip = L("This fan speed is enforced during all infill bridges. It won't slow down the fan if it's currently running at a higher speed."
-        "\nSet to -1 to disable this override (Internal bridges will use Bridges fan speed)."
+        "\nSet to 0 to stop the fan."
+        "\nIf disabled, Bridge fan speed will be used."
         "\nCan be disabled by disable_fan_first_layers and increased by low layer time.");
     def->sidetext = L("%");
-    def->min = -1;
+    def->min = 0;
     def->max = 100;
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionInts{ -1 });
+    def->can_be_disabled = true;
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
     def->aliases = { "bridge_internal_fan_speed" };
 
     def = this->add("internal_bridge_speed", coFloatOrPercent);
@@ -4131,11 +4139,12 @@ void PrintConfigDef::init_fff_params()
         "\nSet to -1 to disable this override (Overhang Perimeter use default fan speed)."
         "\nCan be disabled by disable_fan_first_layers and increased by low layer time.");
     def->sidetext = L("%");
-    def->min = -1;
+    def->min = 0;
     def->max = 100;
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionInts{ -1 });
+    def->can_be_disabled = true;
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
 
     def = this->add("overhangs_max_slope", coFloatOrPercent);
     def->label = L("Overhangs max slope");
@@ -4391,15 +4400,16 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Internal Perimeter fan speed");
     def->category = OptionCategory::cooling;
     def->tooltip = L("This fan speed is enforced during all Perimeter moves"
-        "\nSet to 1 to disable fan."
-        "\nSet to -1 to disable this override (Internal Perimeter use default fan speed)."
+        "\nSet to 0 to stop the fan."
+        "\nIf disabled, default fan speed will be used."
         "\nCan be disabled by disable_fan_first_layers, slowed down by full_fan_speed_layer and increased by low layer time.");
     def->sidetext = L("%");
-    def->min = -1;
+    def->min = 0;
     def->max = 100;
     def->mode = comExpert | comSuSi;
     def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionInts{ -1 });
+    def->can_be_disabled = true;
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
 
     def = this->add("perimeter_loop", coBool);
     def->label = L("Perimeters loop");
@@ -5380,15 +5390,16 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Solid Infill fan speed");
     def->category = OptionCategory::cooling;
     def->tooltip = L("This fan speed is enforced during all Solid Infill moves"
-        "\nSet to 1 to disable fan."
-        "\nSet to -1 to disable this override (Solid Infill will use default fan speed)."
+        "\nSet to 0 to stop the fan."
+        "\nIf disabled, default fan speed will be used."
         "\nCan be disabled by disable_fan_first_layers, slowed down by full_fan_speed_layer and increased by low layer time.");
     def->sidetext = L("%");
-    def->min = -1;
+    def->min = 0;
     def->max = 100;
     def->mode = comExpert | comSuSi;
     def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionInts{ -1 });
+    def->can_be_disabled = true;
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
 
     def = this->add("solid_infill_speed", coFloatOrPercent);
     def->label = L("Solid");
@@ -5757,15 +5768,16 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Support Material fan speed");
     def->category = OptionCategory::cooling;
     def->tooltip = L("This fan speed is enforced during all support moves"
-        "\nSet to 0 to disable fan."
-        "\nSet to -1 to disable this override (Support will use default fan speed)."
+        "\nSet to 0 to stop the fan."
+        "\nIf disabled, default fan speed will be used."
         "\nCan be disabled by disable_fan_first_layers, slowed down by full_fan_speed_layer.");
     def->sidetext = L("%");
-    def->min = -1;
+    def->min = 0;
     def->max = 100;
     def->mode = comExpert | comSuSi;
     def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionInts{ -1 });
+    def->can_be_disabled = true;
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
 
     def = this->add("support_material_interface_angle", coFloat);
     def->label = L("Pattern angle");
@@ -5792,15 +5804,16 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Support interface fan speed");
     def->category = OptionCategory::cooling;
     def->tooltip = L("This fan speed is enforced during all support interfaces, to be able to weaken their bonding with a high fan speed."
-        "\nSet to 0 to disable the fan."
-        "\nSet to -1 to disable this override (Support Interface will use Support)."
+        "\nSet to 0 to stop the fan."
+        "\nIf disabled, Support Material fan speed will be used."
         "\nCan only be overriden by disable_fan_first_layers.");
     def->sidetext = L("%");
-    def->min = -1;
+    def->min = 0;
     def->max = 100;
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionInts{ -1 });
+    def->can_be_disabled = true;
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
 
 
     def = this->add("support_material_interface_contact_loops", coBool);
@@ -6338,15 +6351,16 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Top Solid fan speed");
     def->category = OptionCategory::cooling;
     def->tooltip = L("This fan speed is enforced during all top fills (including ironing)."
-        "\nSet to 1 to disable the fan."
-        "\nSet to -1 to disable this override (Top Solid Infill will use Solid Infill)."
+        "\nSet to 0 to stop the fan."
+        "\nIf disabled, Solid Infill fan speed will be used."
         "\nCan be disabled by disable_fan_first_layers, slowed down by full_fan_speed_layer.");
     def->sidetext = L("%");
-    def->min = -1;
+    def->min = 0;
     def->max = 100;
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
-    def->set_default_value(new ConfigOptionInts{ -1 });
+    def->can_be_disabled = true;
+    def->set_default_value((ConfigOptionInts*)(new ConfigOptionInts({ 100 }))->set_can_be_disabled()->set_enabled(false));
 
     def = this->add("top_infill_extrusion_width", coFloatOrPercent);
     def->label = L("Top solid infill");
@@ -8380,6 +8394,19 @@ void PrintConfigDef::handle_legacy(t_config_option_key &opt_key, std::string &va
             value = "disabled";
     }
 
+    //fan speed: activate disable.
+    if (opt_key.find("_fan_speed") != std::string::npos) {
+        if ("max_fan_speed" != opt_key && "filament_toolchange_part_fan_speed" != opt_key) {
+            if (value == "-1") {
+                value = "!100";
+            } else if (value == "1") {
+                // for now, still consider "1" as a "0", to be able to import old config where the 1 means 0 (and 0
+                // was disable).
+                value = "0";
+            }
+        }
+    }
+
     if (!print_config_def.has(opt_key)) {
         //check the aliases
         for(const auto& entry : print_config_def.options) {
@@ -9257,13 +9284,21 @@ std::map<std::string, std::string> PrintConfigDef::to_prusa(t_config_option_key&
         value = Slic3r::find_full_path(value, value).generic_string();
     }
     if ("default_fan_speed" == opt_key) {
+        if (!value.empty() && value.front() == '!') {
+            value = "1";
+        }
         if (value == "0") {
             opt_key = "min_fan_speed";
-            value = all_conf.option("fan_printer_min_speed")->get_float();
+            value = std::to_string(all_conf.option("fan_printer_min_speed")->get_float());
             new_entries["fan_always_on"] = "0";
         } else {
             opt_key = "min_fan_speed";
             new_entries["fan_always_on"] = "1";
+        }
+    }
+    if ("bridge_fan_speed" == opt_key) {
+        if (!value.empty() && value.front() == '!') {
+            value = std::to_string(all_conf.option("fan_printer_min_speed")->get_float());
         }
     }
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1236,7 +1236,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionPercents,             filament_shrink))
     ((ConfigOptionInts,                 first_layer_bed_temperature))
     ((ConfigOptionInts,                 first_layer_temperature))
-    ((ConfigOptionIntsNullable,         idle_temperature))
+    ((ConfigOptionInts,                 idle_temperature))
     ((ConfigOptionInts,                 full_fan_speed_layer))
     ((ConfigOptionInts,                 gap_fill_fan_speed))
     ((ConfigOptionInts,                 infill_fan_speed))
@@ -1569,20 +1569,20 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                       material_correction_y))
     ((ConfigOptionFloat,                       material_correction_z))
     ((ConfigOptionEnum<SLAMaterialSpeed>,      material_print_speed))
-    ((ConfigOptionFloatNullable,               material_ow_support_pillar_diameter))
-    ((ConfigOptionFloatNullable,               material_ow_branchingsupport_pillar_diameter))
-    ((ConfigOptionFloatNullable,               material_ow_support_head_front_diameter))
-    ((ConfigOptionFloatNullable,               material_ow_branchingsupport_head_front_diameter))
-    ((ConfigOptionFloatNullable,               material_ow_support_head_penetration))
-    ((ConfigOptionFloatNullable,               material_ow_branchingsupport_head_penetration))
-    ((ConfigOptionFloatNullable,               material_ow_support_head_width))
-    ((ConfigOptionFloatNullable,               material_ow_branchingsupport_head_width))
-    ((ConfigOptionIntNullable,                 material_ow_support_points_density_relative))
+    ((ConfigOptionFloat,                       material_ow_support_pillar_diameter))
+    ((ConfigOptionFloat,                       material_ow_branchingsupport_pillar_diameter))
+    ((ConfigOptionFloat,                       material_ow_support_head_front_diameter))
+    ((ConfigOptionFloat,                       material_ow_branchingsupport_head_front_diameter))
+    ((ConfigOptionFloat,                       material_ow_support_head_penetration))
+    ((ConfigOptionFloat,                       material_ow_branchingsupport_head_penetration))
+    ((ConfigOptionFloat,                       material_ow_support_head_width))
+    ((ConfigOptionFloat,                       material_ow_branchingsupport_head_width))
+    ((ConfigOptionInt,                         material_ow_support_points_density_relative))
 
-    ((ConfigOptionFloatNullable,               material_ow_first_layer_size_compensation)) /* material_ow_elefant_foot_compensation */
-    ((ConfigOptionFloatNullable,               material_ow_relative_correction_x))
-    ((ConfigOptionFloatNullable,               material_ow_relative_correction_y))
-    ((ConfigOptionFloatNullable,               material_ow_relative_correction_z))
+    ((ConfigOptionFloat,                       material_ow_first_layer_size_compensation)) /* material_ow_elefant_foot_compensation */
+    ((ConfigOptionFloat,                       material_ow_relative_correction_x))
+    ((ConfigOptionFloat,                       material_ow_relative_correction_y))
+    ((ConfigOptionFloat,                       material_ow_relative_correction_z))
 )
 
 PRINT_CONFIG_CLASS_DEFINE(
@@ -1836,12 +1836,13 @@ public:
     bool         set_key_value(const std::string &opt_key, ConfigOption *opt) { bool out = m_data.set_key_value(opt_key, opt); this->touch(); return out; }
     template<typename T>
     void         set(const std::string &opt_key, T value) { m_data.set(opt_key, value, true); this->touch(); }
-    void set_any(const std::string &opt_key, boost::any value, int16_t extruder_id)
+    void set_any(const std::string &opt_key, bool enable, boost::any value, int16_t extruder_id)
     {
         ConfigOption *opt = m_data.option(opt_key, true);
         assert(opt);
         if (opt) {
             opt->set_any(value, extruder_id);
+            opt->set_enabled(enable, extruder_id);
             this->touch();
         }
     }

--- a/src/libslic3r/SLAPrint.cpp
+++ b/src/libslic3r/SLAPrint.cpp
@@ -236,12 +236,11 @@ static t_config_option_keys print_config_diffs(const StaticPrintConfig     &curr
             //FIXME This may happen when executing some test cases.
             continue;
         const ConfigOption *opt_new_override = std::binary_search(overriden_keys.begin(), overriden_keys.end(), opt_key) ? new_full_config.option(material_ow_prefix + opt_key) : nullptr;
-        if (opt_new_override != nullptr && ! opt_new_override->is_nil()) {
+        if (opt_new_override != nullptr) {
             // An override is available at some of the material presets.
-            bool overriden = opt_new->overriden_by(opt_new_override);
-            if (overriden || *opt_old != *opt_new) {
+            if (*opt_old != *opt_new || opt_new->overriden_by(opt_new_override)) {
                 auto opt_copy = opt_new->clone();
-                opt_copy->apply_override(opt_new_override);
+                bool overriden = opt_copy->apply_override(opt_new_override);
                 bool changed = *opt_old != *opt_copy;
                 if (changed)
                     print_diff.emplace_back(opt_key);

--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -1798,7 +1798,9 @@ void generate_support_toolpaths(
                 if (top_contact_layer.could_merge(interface_layer) && ! raft_layer)
                     top_contact_layer.merge(std::move(interface_layer));
             } 
-            if ((config.support_material_interface_layers == 0 || config.support_material_bottom_interface_layers == 0) && support_params.can_merge_support_regions) {
+            if ( (config.support_material_interface_layers == 0 ||
+                    (config.support_material_bottom_interface_layers.is_enabled() && config.support_material_bottom_interface_layers.value == 0))
+                && support_params.can_merge_support_regions) {
                 if (base_layer.could_merge(bottom_contact_layer))
                     base_layer.merge(std::move(bottom_contact_layer));
                 else if (base_layer.empty() && ! bottom_contact_layer.empty() && ! bottom_contact_layer.layer->bridging)
@@ -1893,7 +1895,9 @@ void generate_support_toolpaths(
                 }
             };
             const bool top_interfaces = config.support_material_interface_layers.value != 0;
-            const bool bottom_interfaces = top_interfaces && config.support_material_bottom_interface_layers != 0;
+            const bool bottom_interfaces = config.support_material_bottom_interface_layers.is_enabled() ?
+                top_interfaces && config.support_material_bottom_interface_layers.value != 0 :
+                top_interfaces;
             extrude_interface(top_contact_layer,    raft_layer ? InterfaceLayerType::RaftContact : top_interfaces ? InterfaceLayerType::TopContact : InterfaceLayerType::InterfaceAsBase);
             extrude_interface(bottom_contact_layer, bottom_interfaces ? InterfaceLayerType::BottomContact : InterfaceLayerType::InterfaceAsBase);
             extrude_interface(interface_layer,      top_interfaces ? InterfaceLayerType::Interface : InterfaceLayerType::InterfaceAsBase);

--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -2267,7 +2267,7 @@ SupportGeneratorLayersPtr PrintObjectSupportMaterial::raft_and_intermediate_supp
             {
                 n_layers_top = m_object_config->support_material_interface_layers.value;
                 coordf_t height_top_interface = std::max(0., support_interface_layer_height * n_layers_top);
-                n_layers_bot = m_object_config->support_material_bottom_interface_layers.value >= 0 ? m_object_config->support_material_bottom_interface_layers.value : n_layers_top;
+                n_layers_bot = m_object_config->support_material_bottom_interface_layers.is_enabled() ? m_object_config->support_material_bottom_interface_layers.value : n_layers_top;
                 n_layers_bot = std::max(size_t(0), n_layers_bot - 1); //the first bot layer is already in the extreme list.
                 coordf_t height_bot_interface = (support_interface_layer_height * n_layers_bot);
                 if (dist <= height_top_interface + height_bot_interface) {

--- a/src/libslic3r/Support/SupportParameters.cpp
+++ b/src/libslic3r/Support/SupportParameters.cpp
@@ -29,8 +29,9 @@ SupportParameters::SupportParameters(const PrintObject &object)
 
     {
         int num_top_interface_layers    = std::max(0, object_config.support_material_interface_layers.value);
-        int num_bottom_interface_layers = object_config.support_material_bottom_interface_layers < 0 ? 
-            num_top_interface_layers : object_config.support_material_bottom_interface_layers;
+        int num_bottom_interface_layers = object_config.support_material_bottom_interface_layers.is_enabled() ?
+            object_config.support_material_bottom_interface_layers :
+            num_top_interface_layers;
         this->has_top_contacts              = num_top_interface_layers    > 0;
         this->has_bottom_contacts           = num_bottom_interface_layers > 0;
         this->num_top_interface_layers      = this->has_top_contacts ? size_t(num_top_interface_layers - 1) : 0;

--- a/src/slic3r/GUI/BedShapeDialog.cpp
+++ b/src/slic3r/GUI/BedShapeDialog.cpp
@@ -130,14 +130,16 @@ void BedShape::apply_optgroup_values(ConfigOptionsGroupShp optgroup)
 {
     switch (m_build_volume.type()) {
     case BuildVolume::Type::Circle:
-        optgroup->set_value("diameter", 2. * unscaled<double>(m_build_volume.circle().radius));
+        optgroup->set_value("diameter", 2. * unscaled<double>(m_build_volume.circle().radius), true, false);
         break;
     default:
         // rectangle, convex, concave...
         optgroup->set_value("rect_size", Vec2d(m_build_volume.bounding_volume().size().x(),
-                                               m_build_volume.bounding_volume().size().y()));
+                                               m_build_volume.bounding_volume().size().y()),
+                                               true, false);
         optgroup->set_value("rect_origin", Vec2d(-m_build_volume.bounding_volume().min.x(),
-                                                 -m_build_volume.bounding_volume().min.y()));
+                                                 -m_build_volume.bounding_volume().min.y()),
+                                                  true, false);
     }
 }
 
@@ -269,7 +271,8 @@ ConfigOptionsGroupShp BedShapePanel::init_shape_options_page(const wxString& tit
     ConfigOptionsGroupShp optgroup = std::make_shared<ConfigOptionsGroup>(panel, _L("Settings"));
 
     optgroup->title_width = 10;
-    optgroup->m_on_change = [this](t_config_option_key opt_key, boost::any value) {
+    optgroup->m_on_change = [this](t_config_option_key opt_key, bool enabled, boost::any value) {
+        assert(enabled);
         update_shape();
     };
 	
@@ -293,7 +296,8 @@ wxPanel* BedShapePanel::init_texture_panel()
     ConfigOptionsGroupShp optgroup = std::make_shared<ConfigOptionsGroup>(panel, _L("Texture"));
 
     optgroup->title_width = 10;
-    optgroup->m_on_change = [this](t_config_option_key opt_key, boost::any value) {
+    optgroup->m_on_change = [this](t_config_option_key opt_key, bool enabled, boost::any value) {
+        assert(enabled);
         update_shape();
     };
 
@@ -374,7 +378,8 @@ wxPanel* BedShapePanel::init_model_panel()
     ConfigOptionsGroupShp optgroup = std::make_shared<ConfigOptionsGroup>(panel, _L("Model"));
 
     optgroup->title_width = 10;
-    optgroup->m_on_change = [this](t_config_option_key opt_key, boost::any value) {
+    optgroup->m_on_change = [this](t_config_option_key opt_key, bool enabled, boost::any value) {
+        assert(enabled);
         update_shape();
     };
 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -353,7 +353,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
 
     bool has_spiral_vase = have_perimeters && config->opt_bool("spiral_vase");
     
-    bool have_arachne = have_perimeters && (config->opt_int("perimeters") == config->opt_int("perimeters_hole") || config->opt_int("perimeters_hole") < 0);
+    bool have_arachne = have_perimeters && (config->opt_int("perimeters") == config->opt_int("perimeters_hole") || !config->is_enabled("perimeters_hole"));
     toggle_field("perimeter_generator", have_arachne);
     have_arachne = have_arachne && config->opt_enum<PerimeterGeneratorType>("perimeter_generator") == PerimeterGeneratorType::Arachne;
     for (auto el : { "wall_transition_length", "wall_transition_filter_deviation", "wall_transition_angle", "wall_distribution_count", "min_feature_size", "min_bead_width", "aaa" })
@@ -472,6 +472,9 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
 
     for (auto el : { "hole_to_polyhole_threshold", "hole_to_polyhole_twisted" })
         toggle_field(el, config->opt_bool("hole_to_polyhole"));
+
+    for (auto el : { "overhangs_bridge_threshold", "overhangs_bridge_upper_layers" })
+        toggle_field(el, config->get_float("overhangs_max_slope") > 0);
 
     bool have_skirt = config->opt_int("skirts") > 0;
     toggle_field("skirt_height", have_skirt && config->opt_enum<DraftShield>("draft_shield") != dsEnabled);

--- a/src/slic3r/GUI/CreateMMUTiledCanvas.cpp
+++ b/src/slic3r/GUI/CreateMMUTiledCanvas.cpp
@@ -575,8 +575,7 @@ void CreateMMUTiledCanvas::save_config()
 {
     std::string config_str;
     for (const std::string& key : m_config.keys())
-        if (!m_config.option(key)->is_nil())
-            config_str += key + " = " + m_config.opt_serialize(key) + "\n";
+        config_str += key + " = " + m_config.opt_serialize(key) + "\n";
 
     boost::filesystem::path path_dir = Slic3r::data_dir();
     path_dir = path_dir / "generator";
@@ -1103,7 +1102,8 @@ void CreateMMUTiledCanvas::create_main_tab(wxPanel* tab)
 
 
     group_size = std::make_shared<ConfigOptionsGroup>(tab, "Options", &m_config);
-    group_size->m_on_change = [this](t_config_option_key opt_key, boost::any value) {
+    group_size->m_on_change = [this](t_config_option_key opt_key, bool enabled, boost::any value) {
+        assert(enabled);
         m_dirty = true;
         this->get_canvas()->Refresh();// paintNow();
         this->save_config();
@@ -1150,7 +1150,8 @@ void CreateMMUTiledCanvas::create_main_tab(wxPanel* tab)
 
 
     group_colors = std::make_shared<ConfigOptionsGroup>(tab, "Colors", &m_config);
-    group_colors->m_on_change = [this](t_config_option_key opt_key, boost::any value) {
+    group_colors->m_on_change = [this](t_config_option_key opt_key, bool enabled, boost::any value) {
+        assert(enabled);
         if ("extruders" == opt_key) {
             dynamic_cast<TabPrinter*>(this->m_gui_app->get_tab(Preset::TYPE_PRINTER))->extruders_count_changed(boost::any_cast<int>(value));
         }

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -120,6 +120,27 @@ std::pair<bool, bool> get_strings_points(const wxString &str, double min, double
     return {invalid_val, out_of_range_val};
 }
 
+const wxBitmapBundle *UndoValueUIManager::enable_bitmap() const {
+    if (!has_enable_ui())
+        return nullptr;
+    assert(m_enable_ui.m_on && m_enable_ui.m_off);
+    const wxBitmapBundle *bmp = nullptr;
+    if (m_enable_ui.is_hover) {
+        if (m_enable_ui.is_checked) {
+            bmp = &m_enable_ui.m_on_hover->bmp();
+        } else {
+            bmp = &m_enable_ui.m_off_hover->bmp();
+        }
+    } else {
+        if (m_enable_ui.is_checked) {
+            bmp = &m_enable_ui.m_on->bmp();
+        } else {
+            bmp = &m_enable_ui.m_off->bmp();
+        }
+    }
+    return bmp;
+}
+
 Field::~Field()
 {
 	if (m_on_kill_focus)
@@ -216,7 +237,7 @@ void Field::on_change_field()
 {
 //       std::cerr << "calling Field::_on_change \n";
     if (m_on_change != nullptr && !m_disable_change_event) {
-        m_on_change(m_opt_id, get_value());
+        m_on_change(m_opt_id, is_setting_enabled(), get_value());
     }
 }
 
@@ -236,6 +257,34 @@ void Field::on_edit_value()
 {
 	if (m_fn_edit_value)
 		m_fn_edit_value(m_opt_id);
+}
+
+void Field::on_enable_value()
+{
+    //switch the value of the decorator
+    if (has_enable_ui() && is_widget_enabled()) {
+        m_enable_ui.is_checked = !m_enable_ui.is_checked;
+        // update enable if needed
+        if (is_widget_enabled()) {
+            widget_enable();
+            if (m_enable_ui.is_checked) {
+                getWindow()->SetFocus();
+            }
+        }
+        //call update for the setting and the decorator (via tab.cpp). It should update the decoration.
+        on_change_field();
+    }
+}
+
+
+void Field::set_any_value(const boost::any &value, bool change_event) {
+    m_disable_change_event = !change_event;
+    set_internal_any_value(value, change_event);
+    m_disable_change_event = false;
+    // update enable if needed
+    if (is_widget_enabled()) {
+        widget_enable();
+    }
 }
 
 wxString Field::get_tooltip_text(const wxString& default_string)
@@ -335,8 +384,31 @@ void Field::set_tooltip(const wxString& default_string, wxWindow* window) {
                 }
             }
             });
-    } else
-        window->SetToolTip(get_tooltip_text(default_string));
+    } else {
+        m_last_tooltip = get_tooltip_text(default_string);
+        window->SetToolTip(m_last_tooltip);
+    }
+}
+
+const wxBitmapBundle *Field::enable_bitmap() const {
+    if (!has_enable_ui())
+        return nullptr;
+    if (!m_is_enable) {
+        if (m_enable_ui.is_checked) {
+            return &m_enable_ui.m_on_disabled->bmp();
+        } else {
+            return &m_enable_ui.m_off_disabled->bmp();
+        }
+    }
+    return UndoValueUIManager::enable_bitmap();
+}
+
+const wxString *Field::enable_tooltip() const {
+    if (!m_enable_ui.is_checked && !m_last_tooltip.empty()) {
+        return &m_last_tooltip;
+    } else {
+        return &m_enable_ui.tooltip;
+    }
 }
 
 void RichTooltipTimer::Notify() {
@@ -347,9 +419,10 @@ void RichTooltipTimer::Notify() {
         ) {
         this->m_previous_focus = wxGetActiveWindow()->FindFocus();
         this->m_current_rich_tooltip = nullptr;
+        m_field->m_last_tooltip = m_field->get_rich_tooltip_text(this->m_value);
         wxRichToolTip richTooltip(
             m_field->get_rich_tooltip_title(this->m_value),
-            m_field->get_rich_tooltip_text(this->m_value));
+            m_field->m_last_tooltip);
         richTooltip.SetTimeout(120000, 0);
         richTooltip.ShowFor(m_current_window);
         wxWindowList tipWindow = m_current_window->GetChildren();
@@ -384,26 +457,14 @@ bool Field::is_matched(const std::string &string, const std::string &pattern)
 	return std::regex_match(string, regex_pattern);
 }
 
-static wxString na_value(bool for_spin_ctrl = false)
-{
-#ifdef __linux__
-    if (for_spin_ctrl)
-        return "";
-#endif
-    return _(L("N/A"));
-}
-
 // return the string to set, and bool if there is a nil value
-std::pair<wxString, bool> any_to_wxstring(const boost::any &value, const ConfigOptionDef &opt, const int opt_idx)
+wxString any_to_wxstring(const boost::any &value, const ConfigOptionDef &opt, const int opt_idx)
 {
     wxString text_value;
-    bool     has_nil = false;
-    auto deserialize = [&text_value, &value, &opt, &has_nil](ConfigOptionVectorBase &&writer, bool check_nil = true) {
+    auto deserialize = [&text_value, &value, &opt](ConfigOptionVectorBase &&writer, bool check_nil = true) {
         //TODO: test (this codepath isn't used yet)
         writer.set_any(value, 0); // serialize one value into this empty vector, so first item
         text_value = writer.serialize();
-        if (check_nil && opt.nullable)
-            has_nil = (text_value.Replace(NIL_STR_VALUE, na_value()) > 0);
         //replace ',' by ';'
         text_value.Replace(",", ";");
         if (!is_decimal_separator_point()) {
@@ -416,39 +477,18 @@ std::pair<wxString, bool> any_to_wxstring(const boost::any &value, const ConfigO
     switch (opt.type) {
     case coFloats: {
         if (opt_idx < 0) {
-            if(opt.nullable)
-                deserialize(ConfigOptionFloatsNullable{});
-            else
-                deserialize(ConfigOptionFloats{});
+            deserialize(ConfigOptionFloats{});
             break;
         }
     }
     case coPercents: {
         if (opt_idx < 0) {
-            if(opt.nullable)
-                deserialize(ConfigOptionPercentsNullable{});
-            else
-                deserialize(ConfigOptionPercents{});
-            break;
-        }
-        if (opt.nullable && ConfigOptionFloatNullable::is_any_nil(value)) {
-            text_value = na_value();
-            has_nil    = true;
+            deserialize(ConfigOptionPercents{});
             break;
         }
     }
     case coFloat:
-        if(opt.nullable  && ConfigOptionFloatNullable::is_any_nil(value)) {
-            text_value = na_value();
-            has_nil    = true;
-            break;
-        }
     case coPercent: {
-        if(opt.nullable  && ConfigOptionFloatNullable::is_any_nil(value)) {
-            text_value = na_value();
-            has_nil    = true;
-            break;
-        }
         text_value = double_to_string(boost::any_cast<double>(value), opt.precision);
         break;
     }
@@ -477,7 +517,6 @@ std::pair<wxString, bool> any_to_wxstring(const boost::any &value, const ConfigO
             text_value = good_str;
             break;
         }
-        // can't be nullable
     }
     case coString: {
         text_value = boost::any_cast<std::string>(value);
@@ -485,15 +524,7 @@ std::pair<wxString, bool> any_to_wxstring(const boost::any &value, const ConfigO
     }
     case coFloatsOrPercents: {
         if (opt_idx < 0) {
-            if (opt.nullable)
-                deserialize(ConfigOptionFloatsOrPercentsNullable{});
-            else
-                deserialize(ConfigOptionFloatsOrPercents{});
-            break;
-        }
-        if (opt.nullable && ConfigOptionFloatsOrPercentsNullable::is_any_nil(value)) {
-            text_value = na_value();
-            has_nil    = true;
+            deserialize(ConfigOptionFloatsOrPercents{});
             break;
         }
     }
@@ -506,16 +537,8 @@ std::pair<wxString, bool> any_to_wxstring(const boost::any &value, const ConfigO
     }
     case coBools: {
         if (opt_idx < 0) {
-            if (opt.nullable)
-                deserialize(ConfigOptionBoolsNullable{});
-            else
-                deserialize(ConfigOptionBools{});
+            deserialize(ConfigOptionBools{});
         } else {
-            if (opt.nullable && boost::any_cast<uint8_t>(value) == ConfigOptionBoolsNullable::NIL_VALUE()) {
-                text_value = na_value();
-                has_nil    = true;
-                break;
-            }
             text_value = boost::any_cast<uint8_t>(value) != 0 ? "true" : "false";
         }
         break;
@@ -528,24 +551,11 @@ std::pair<wxString, bool> any_to_wxstring(const boost::any &value, const ConfigO
     }
     case coInts: {
         if (opt_idx < 0) {
-            if(opt.nullable)
-                deserialize(ConfigOptionIntsNullable{});
-            else
-                deserialize(ConfigOptionInts{});
-            break;
-        }
-        if (opt.nullable && ConfigOptionIntNullable::is_any_nil(value)) {
-            text_value = na_value();
-            has_nil    = true;
+            deserialize(ConfigOptionInts{});
             break;
         }
     }
     case coInt: {
-        if(opt.nullable  && ConfigOptionIntNullable::is_any_nil(value)) {
-            text_value = na_value();
-            has_nil    = true;
-            break;
-        }
         text_value = wxString::Format(_T("%i"), int(boost::any_cast<int>(value)));
         break;
     }
@@ -559,8 +569,9 @@ std::pair<wxString, bool> any_to_wxstring(const boost::any &value, const ConfigO
         text_value = get_points_string({boost::any_cast<Vec2d>(value)});
         break;
     }
+    default: assert(false);
     }
-    return {text_value, has_nil};
+    return text_value;
 }
 
 // return true if the field isn't the same as before
@@ -598,10 +609,6 @@ bool TextField::get_vector_value(const wxString &str, ConfigOptionVectorBase &re
 void TextField::get_value_by_opt_type(wxString &str, const bool check_value /* = true*/)
 {
     bool need_update = false;
-    // convert nil values to serializable ones
-    if (m_opt.nullable && (m_opt.type != coString && m_opt.type != coStrings)) {
-        need_update = str.Replace(na_value(), NIL_STR_VALUE);
-    }
 
     // val is needed at the end of this function, for "max_volumetric_speed" || "gap_fill_speed" (bad practice)
     double val = 0;
@@ -614,10 +621,7 @@ void TextField::get_value_by_opt_type(wxString &str, const bool check_value /* =
             break;
         } // else: one int on m_opt_idx, done below
     case coInt: {
-        if (m_opt.nullable && str == NIL_STR_VALUE)
-            val = ConfigOptionIntNullable::nil_value();
-        else
-            val = wxAtoi(str);
+        val = wxAtoi(str);
         m_value = int32_t(val);
         break;
     }
@@ -663,24 +667,17 @@ void TextField::get_value_by_opt_type(wxString &str, const bool check_value /* =
             break;
         }
 
-        bool is_na_value = m_opt.nullable && str == NIL_STR_VALUE;
-
         const char dec_sep     = is_decimal_separator_point() ? '.' : ',';
         const char dec_sep_alt = dec_sep == '.' ? ',' : '.';
-        // Replace the first incorrect separator in decimal number,
-        // if this value doesn't "N/A" value in some language
+        // Replace the first incorrect separator in decimal number
         // see https://github.com/prusa3d/PrusaSlicer/issues/6921
-        if (!is_na_value && str.Replace(dec_sep_alt, dec_sep, false) != 0)
+        if (str.Replace(dec_sep_alt, dec_sep, false) != 0)
             set_text_value(str.ToStdString(), false);
 
         if (str == dec_sep)
             val = 0.0;
         else {
-            if (is_na_value) {
-                val     = NAN;
-                m_value = ConfigOptionFloatNullable::nil_value();
-                break;
-            } else if (!str.ToDouble(&val)) {
+            if (!str.ToDouble(&val)) {
                 if (!check_value) {
                     m_value.clear();
                     break;
@@ -822,10 +819,7 @@ void TextField::get_value_by_opt_type(wxString &str, const bool check_value /* =
                 str.Replace(" ", "", true);
                 str.Replace("m", "", true);
 
-                if (m_opt.nullable && str == NIL_STR_VALUE) {
-                    m_value = ConfigOptionFloatsOrPercentsNullable::create_any_nil();
-                    break;
-                } else if (!str.ToDouble(&val)) {
+                if (!str.ToDouble(&val)) {
                     if (!check_value) {
                         m_value.clear();
                         break;
@@ -965,7 +959,7 @@ void TextField::get_value_by_opt_type(wxString &str, const bool check_value /* =
     }
 
     if (need_update) {
-        wxString new_str = any_to_wxstring(m_value, m_opt, m_opt_idx).first;
+        wxString new_str = any_to_wxstring(m_value, m_opt, m_opt_idx);
         set_text_value(new_str.ToStdString());
     }
 }
@@ -1000,15 +994,7 @@ void TextCtrl::BUILD() {
 	wxString text_value = wxString("");
 
     boost::any anyval = m_opt.default_value->get_any(m_opt_idx);
-    text_value = any_to_wxstring(m_opt.default_value->get_any(m_opt_idx), m_opt, m_opt_idx).first;
-    if (text_value == na_value()) {
-        // current value is nil, get the not-nil default value of the default option.
-        assert(m_opt.default_value->is_vector());
-        m_last_meaningful_value = any_to_wxstring(static_cast<const ConfigOptionVectorBase*>(m_opt.default_value.get())->get_default_value(), m_opt, m_opt_idx).first;
-    } else {
-        m_last_meaningful_value = text_value;
-    }
-    assert(m_last_meaningful_value != na_value());
+    text_value = any_to_wxstring(m_opt.default_value->get_any(m_opt_idx), m_opt, m_opt_idx);
 
     long style = m_opt.multiline ? wxTE_MULTILINE : wxTE_PROCESS_ENTER;
 	auto temp = new text_ctrl(m_parent, text_value, "", "", wxDefaultPosition, size, style);
@@ -1070,7 +1056,11 @@ void TextCtrl::BUILD() {
     // recast as a wxWindow to fit the calling convention
     window = dynamic_cast<wxWindow*>(temp);
 
-    this->set_tooltip(text_value);
+    if (m_opt.default_value->is_enabled(m_opt_idx)) {
+        this->set_tooltip(text_value);
+    } else {
+        this->set_tooltip(wxString("Disabled (") + text_value + ")");
+    }
 }
 
 void TextCtrl::set_text_value(const std::string &value, bool change_event)
@@ -1096,41 +1086,15 @@ bool TextCtrl::value_was_changed()
         if (m_opt_idx < 0) {
             return boost::any_cast<std::vector<int>>(m_value) != boost::any_cast<std::vector<int>>(val);
         }
-        if (m_opt.nullable) {
-            uint8_t new_val = boost::any_cast<uint8_t>(m_value);
-            uint8_t old_val = boost::any_cast<uint8_t>(val);
-            if (new_val == ConfigOptionIntNullable::nil_value() && old_val == ConfigOptionIntNullable::nil_value())
-                return false;
-        }
     case coInt:
-        if (m_opt.nullable) {
-            uint8_t new_val = boost::any_cast<uint8_t>(m_value);
-            uint8_t old_val = boost::any_cast<uint8_t>(val);
-            if (new_val == ConfigOptionIntNullable::nil_value() && old_val == ConfigOptionIntNullable::nil_value())
-                return false;
-        }
         return boost::any_cast<int>(m_value) != boost::any_cast<int>(val);
     case coPercents:
     case coFloats:
         if (m_opt_idx < 0) {
             return boost::any_cast<std::vector<double>>(m_value) != boost::any_cast<std::vector<double>>(val);
         }
-        if (m_opt.nullable) {
-            double new_val = boost::any_cast<double>(m_value);
-            double old_val = boost::any_cast<double>(val);
-            if ((std::isnan(new_val) || ConfigOptionFloatNullable::is_any_nil(m_value)) &&
-                (std::isnan(old_val) || ConfigOptionFloatNullable::is_any_nil(val)))
-            return false;
-        }
     case coPercent:
     case coFloat: {
-        if (m_opt.nullable) {
-            double new_val = boost::any_cast<double>(m_value);
-            double old_val = boost::any_cast<double>(val);
-            if ((std::isnan(new_val) || ConfigOptionFloatNullable::is_any_nil(m_value)) &&
-                (std::isnan(old_val) || ConfigOptionFloatNullable::is_any_nil(val)))
-            return false;
-        }
         return boost::any_cast<double>(m_value) != boost::any_cast<double>(val);
     }
     case coStrings:
@@ -1145,15 +1109,7 @@ bool TextCtrl::value_was_changed()
             return boost::any_cast<std::vector<FloatOrPercent>>(m_value) !=
                    boost::any_cast<std::vector<FloatOrPercent>>(val);
         }
-        if (m_opt.nullable) {
-            if (ConfigOptionFloatsOrPercents::is_any_nil(m_value) &&ConfigOptionFloatsOrPercents::is_any_nil(val))
-                return false;
-        }
     case coFloatOrPercent:
-        if (m_opt.nullable) {
-            if (ConfigOptionFloatOrPercent::is_any_nil(m_value) &&ConfigOptionFloatOrPercent::is_any_nil(val))
-                return false;
-        }
         return boost::any_cast<FloatOrPercent>(m_value) != boost::any_cast<FloatOrPercent>(val);
     case coPoints:
         if (m_opt_idx < 0) {
@@ -1168,12 +1124,6 @@ bool TextCtrl::value_was_changed()
         if (m_opt_idx < 0) {
             return boost::any_cast<std::vector<uint8_t>>(m_value) != boost::any_cast<std::vector<uint8_t>>(val);
         } else {
-            if (m_opt.nullable) {
-                uint8_t new_val = boost::any_cast<uint8_t>(m_value);
-                uint8_t old_val = boost::any_cast<uint8_t>(val);
-                if (new_val == ConfigOptionBools::NIL_VALUE() && old_val == ConfigOptionBools::NIL_VALUE())
-                    return false;
-            }
             return boost::any_cast<uint8_t>(m_value) != boost::any_cast<uint8_t>(val);
         }
     case coBool:
@@ -1188,11 +1138,6 @@ bool TextCtrl::value_was_changed()
 
 void TextCtrl::propagate_value()
 {
-    //update m_last_meaningful_value
-    wxString val = dynamic_cast<text_ctrl*>(window)->GetValue();
-    if (!m_value.empty() && (!m_opt.nullable || val != na_value()))
-        m_last_meaningful_value = val;
-
     if (!is_defined_input_value<text_ctrl>(window, m_opt.type) )
 		// on_kill_focus() cause a call of OptionsGroup::reload_config(),
 		// Thus, do it only when it's really needed (when undefined value was input)
@@ -1201,7 +1146,7 @@ void TextCtrl::propagate_value()
         on_change_field();
 }
 
-void TextCtrl::set_any_value(const boost::any& value, bool change_event/* = false*/) {
+void TextCtrl::set_internal_any_value(const boost::any& value, bool change_event/* = false*/) {
     //can be:
     //case coFloat:
     //case coFloats:
@@ -1214,11 +1159,10 @@ void TextCtrl::set_any_value(const boost::any& value, bool change_event/* = fals
     // coBools (if all)
     // coInts (if all)
     // coPoints (if all)
-    auto [/*wxString*/text_value, /*bool*/ has_nil] = any_to_wxstring(value, m_opt, m_opt_idx);
-    if (!has_nil)
-        m_last_meaningful_value = text_value;
-    m_disable_change_event = !change_event;
+    wxString text_value = any_to_wxstring(value, m_opt, m_opt_idx);
     dynamic_cast<text_ctrl *>(window)->SetValue(text_value);
+
+    //is it really needed? i don't think so
     m_disable_change_event = false;
 
     if (!change_event) {
@@ -1229,18 +1173,6 @@ void TextCtrl::set_any_value(const boost::any& value, bool change_event/* = fals
          */
         get_value_by_opt_type(ret_str, false);
     }
-}
-
-void TextCtrl::set_last_meaningful_value()
-{
-    dynamic_cast<text_ctrl*>(window)->SetValue(m_last_meaningful_value);
-    propagate_value();
-}
-
-void TextCtrl::set_na_value()
-{
-    dynamic_cast<text_ctrl*>(window)->SetValue(na_value());
-    propagate_value();
 }
 
 boost::any& TextCtrl::get_value()
@@ -1277,8 +1209,14 @@ void TextCtrl::msw_rescale()
 
 }
 
-void TextCtrl::enable()  { dynamic_cast<text_ctrl*>(window)->Enable(); }
-void TextCtrl::disable() { dynamic_cast<text_ctrl*>(window)->Disable();}
+void TextCtrl::widget_enable()  { 
+    if (is_setting_enabled()) {
+        dynamic_cast<text_ctrl *>(window)->Enable();
+    } else {
+        widget_disable();
+    }
+}
+void TextCtrl::widget_disable() { dynamic_cast<text_ctrl*>(window)->Disable();}
 
 #ifdef __WXGTK__
 void TextCtrl::change_field_value(wxEvent& event)
@@ -1386,9 +1324,7 @@ void CheckBox::BUILD() {
         m_opt.default_value->get_bool(m_opt_idx) :
         false;
 
-    m_last_meaningful_value = static_cast<unsigned char>(check_value);
-
-        // Set Label as a string of at least one space simbol to correct system scaling of a CheckBox
+    // Set Label as a string of at least one space simbol to correct system scaling of a CheckBox
     window = GetNewWin(m_parent); //m_opt.is_script ? wxCHK_3STATE : wxCHK_2STATE);
     wxGetApp().UpdateDarkUI(window);
 	window->SetFont(wxGetApp().normal_font());
@@ -1403,7 +1339,6 @@ void CheckBox::BUILD() {
     //gtk2 can't resize checkboxes, so we are using togglable buttons instead
     window->Bind(wxEVT_TOGGLEBUTTON, ([this](wxCommandEvent e) {
         if (wxToggleButton* chk = dynamic_cast<wxToggleButton*>(window)) {
-            m_is_na_val = false;
             if (chk->GetValue())
                 chk->SetLabel("X");
             else
@@ -1413,13 +1348,16 @@ void CheckBox::BUILD() {
     }), window->GetId());
 #else
 	window->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent e) {
-        m_is_na_val = false;
 	    on_change_field();
 	});
 #endif
 
     // you need to set the window before the tooltip
-    this->set_tooltip(check_value ? "true" : "false");
+    if (m_opt.default_value->is_enabled(m_opt_idx)) {
+        this->set_tooltip(check_value ? "true" : "false");
+    } else {
+        this->set_tooltip(check_value ? "Disabled (true)" : "Disabled (false)");
+    }
 }
 
 void CheckBox::set_bool_value(const bool new_val, bool change_event)
@@ -1429,17 +1367,11 @@ void CheckBox::set_bool_value(const bool new_val, bool change_event)
     m_disable_change_event = false;
 }
 
-void CheckBox::set_any_value(const boost::any& value, bool change_event)
+void CheckBox::set_internal_any_value(const boost::any& value, bool change_event)
 {
     //can be coBool and coBools (with idx)
-    m_disable_change_event = !change_event;
     assert(m_opt.type == coBool || (m_opt.type == coBools && m_opt_idx >= 0));
-    if (m_opt.type == coBools && m_opt.nullable) {
-        m_is_na_val = boost::any_cast<uint8_t>(value) == ConfigOptionBoolsNullable::NIL_VALUE();
-        if (!m_is_na_val)
-            m_last_meaningful_value = boost::any_cast<uint8_t>(value);
-        CheckBox::SetValue(window, m_is_na_val ? false : boost::any_cast<unsigned char>(value) != 0);
-    } else if (m_opt.is_script) {
+    if (m_opt.is_script) {
         uint8_t val = boost::any_cast<uint8_t>(value);
         if (val == uint8_t(2) && dynamic_cast<wxCheckBox*>(window) != nullptr) // dead code, no more wxCheckBox. have to modify the custom button state to retreive that.
             dynamic_cast<wxCheckBox*>(window)->Set3StateValue(wxCheckBoxState::wxCHK_UNDETERMINED);
@@ -1451,24 +1383,6 @@ void CheckBox::set_any_value(const boost::any& value, bool change_event)
         assert(m_opt.type == coBool);
         CheckBox::SetValue(window, boost::any_cast<bool>(value));
     }
-    m_disable_change_event = false;
-}
-
-void CheckBox::set_last_meaningful_value()
-{
-    if (m_opt.nullable) {
-        m_is_na_val = false;
-        CheckBox::SetValue(window, m_last_meaningful_value != 0);
-        on_change_field();
-    }
-}
-
-void CheckBox::set_na_value()
-{
-    if (m_opt.nullable) {
-        m_is_na_val = true;
-        on_change_field();
-    }
 }
 
 boost::any& CheckBox::get_value()
@@ -1477,7 +1391,7 @@ boost::any& CheckBox::get_value()
 	if (m_opt.type == coBool)
 		m_value = static_cast<bool>(value);
 	else
-		m_value = m_is_na_val ? ConfigOptionBoolsNullable::NIL_VALUE() : static_cast<unsigned char>(value);
+		m_value = static_cast<unsigned char>(value);
  	return m_value;
 }
 
@@ -1494,12 +1408,15 @@ void CheckBox::sys_color_changed()
         switch_btn->SysColorChange();
 }
 
-void CheckBox::enable()
-{
-    window->Enable();
+void CheckBox::widget_enable() {
+    if (is_setting_enabled()) {
+        window->Enable();
+    } else {
+        window->Disable();
+    }
 }
 
-void CheckBox::disable()
+void CheckBox::widget_disable()
 {
     window->Disable();
 }
@@ -1525,22 +1442,10 @@ void SpinCtrl::BUILD() {
 	switch (m_opt.type) {
 	case coInt:
 		default_value = m_opt.default_value->get_int();
-        if (m_opt.nullable) {
-            if (default_value == ConfigOptionIntNullable::nil_value())
-                m_last_meaningful_value = get_default_int(m_opt.min, m_opt.max);
-            else
-                m_last_meaningful_value = default_value;
-		}
 		break;
 	case coInts:
 	{
         default_value = m_opt.get_default_value<ConfigOptionInts>()->get_at(m_opt_idx);
-        if (m_opt.nullable) {
-            if (default_value == ConfigOptionIntNullable::nil_value())
-                m_last_meaningful_value = m_opt.opt_key == "idle_temperature" ? 30 : get_default_int(m_opt.min, m_opt.max);
-            else
-                m_last_meaningful_value = default_value;
-		}
 		break;
 	}
 	default:
@@ -1614,49 +1519,23 @@ void SpinCtrl::BUILD() {
 	window = dynamic_cast<wxWindow*>(temp);
 
     //problem: it has 2 windows, with a child: the mouse enter event won't fire if in children! (also it need the windoww, so put it after)
-    this->set_tooltip(text_value);
+    if (m_opt.default_value->is_enabled(m_opt_idx)) {
+        this->set_tooltip(text_value);
+    } else {
+        this->set_tooltip(wxString("Disabled (") + text_value + ")");
+    }
 }
 
-void SpinCtrl::set_any_value(const boost::any& value, bool change_event/* = false*/)
+void SpinCtrl::set_internal_any_value(const boost::any& value, bool change_event/* = false*/)
 {
-    m_disable_change_event = !change_event;
     tmp_value = boost::any_cast<int32_t>(value);
     m_value = value;
-    if (m_opt.nullable) {
-        const bool m_is_na_val = tmp_value == ConfigOptionIntNullable::nil_value();
-        if (m_is_na_val)
-            dynamic_cast<::SpinInput*>(window)->SetValue(na_value(true));
-        else {
-            m_last_meaningful_value = tmp_value;
-            dynamic_cast<::SpinInput*>(window)->SetValue(tmp_value);
-        }
-    }
-    else
-        dynamic_cast<::SpinInput*>(window)->SetValue(tmp_value);
-    m_disable_change_event = false;
-}
-
-void SpinCtrl::set_last_meaningful_value()
-{
-    dynamic_cast<::SpinInput*>(window)->SetValue(m_last_meaningful_value);
-    tmp_value = m_last_meaningful_value;
-    propagate_value();
-}
-
-void SpinCtrl::set_na_value()
-{
-    dynamic_cast<::SpinInput*>(window)->SetValue(na_value(true));
-    m_value = ConfigOptionIntNullable::nil_value();
-    propagate_value();
+    dynamic_cast<::SpinInput*>(window)->SetValue(tmp_value);
 }
 
 boost::any& SpinCtrl::get_value()
 {
     ::SpinInput* spin = static_cast<::SpinInput*>(window);
-    if (spin->GetTextValue() == na_value(true)) {
-        assert(boost::any_cast<int32_t>(m_value) == ConfigOptionIntNullable::nil_value());
-        return m_value;
-    }
 
     int32_t value = spin->GetValue();
     return m_value = value;
@@ -1667,9 +1546,6 @@ void SpinCtrl::propagate_value()
     // check if value was really changed
     if (!m_value.empty() && boost::any_cast<int>(m_value) == tmp_value)
         return;
-
-    if (m_opt.nullable && tmp_value != ConfigOptionIntNullable::nil_value())
-        m_last_meaningful_value = tmp_value;
 
     if (tmp_value == UNDEF_VALUE) {
         on_kill_focus();
@@ -1784,7 +1660,11 @@ void Choice::BUILD() {
         } );
     }
 
-    this->set_tooltip(temp->GetValue());
+    if (m_opt.default_value->is_enabled(m_opt_idx)) {
+        this->set_tooltip(temp->GetValue());
+    } else {
+        this->set_tooltip(wxString("Disabled (") + temp->GetValue() + ")");
+    }
 }
 
 void Choice::propagate_value()
@@ -1888,7 +1768,7 @@ void Choice::set_text_value(const std::string &value, bool change_event) //! Red
 	m_disable_change_event = false;
 }
 
-void Choice::set_any_value(const boost::any &value, bool change_event)
+void Choice::set_internal_any_value(const boost::any &value, bool change_event)
 {
     // can be
     // GUIType::select_open
@@ -1898,7 +1778,6 @@ void Choice::set_any_value(const boost::any &value, bool change_event)
     assert(m_opt.type == coEnum || m_opt.gui_type == ConfigOptionDef::GUIType::select_open ||
            m_opt.gui_type == ConfigOptionDef::GUIType::f_enum_open ||
            m_opt.gui_type == ConfigOptionDef::GUIType::i_enum_open);
-	m_disable_change_event = !change_event;
 
     choice_ctrl* field = dynamic_cast<choice_ctrl*>(window);
 
@@ -1909,7 +1788,7 @@ void Choice::set_any_value(const boost::any &value, bool change_event)
 	case coFloatOrPercent:
 	case coString:
 	case coStrings: {
-        auto [/*wxString*/ text_value, /*bool*/ has_nil] = any_to_wxstring(value, m_opt, m_opt_idx);
+        wxString text_value = any_to_wxstring(value, m_opt, m_opt_idx);
         int sel_idx = -1;
         if (m_opt.enum_def) {
             if (auto idx = m_opt.enum_def->label_to_index(into_u8(text_value)); idx.has_value())
@@ -1948,8 +1827,6 @@ void Choice::set_any_value(const boost::any &value, bool change_event)
 	default:
 		break;
 	}
-
-	m_disable_change_event = false;
 }
 
 //! it's needed for _update_serial_ports()
@@ -2036,8 +1913,15 @@ boost::any& Choice::get_value()
 	return m_value;
 }
 
-void Choice::enable()  { dynamic_cast<choice_ctrl*>(window)->Enable(); }
-void Choice::disable() { dynamic_cast<choice_ctrl*>(window)->Disable(); }
+void Choice::widget_enable() {
+    if (is_setting_enabled()) {
+        dynamic_cast<choice_ctrl *>(window)->Enable();
+    } else {
+        widget_disable();
+    }
+}
+
+void Choice::widget_disable() { dynamic_cast<choice_ctrl*>(window)->Disable(); }
 
 void Choice::msw_rescale()
 {
@@ -2122,7 +2006,11 @@ void ColourPicker::BUILD()
 
     window->Bind(wxEVT_COLOURPICKER_CHANGED, ([this](wxCommandEvent e) { on_change_field(); }), window->GetId());
 
-    this->set_tooltip(clr.GetAsString());
+    if (m_opt.default_value->is_enabled(m_opt_idx)) {
+        this->set_tooltip(clr.GetAsString());
+    } else {
+        this->set_tooltip(wxString("Disabled (") + clr.GetAsString() + ")");
+    }
 }
 
 void ColourPicker::set_undef_value(wxColourPickerCtrl* field)
@@ -2143,10 +2031,9 @@ void ColourPicker::set_undef_value(wxColourPickerCtrl* field)
     btn->SetBitmapLabel(bmp);
 }
 
-void ColourPicker::set_any_value(const boost::any &value, bool change_event)
+void ColourPicker::set_internal_any_value(const boost::any &value, bool change_event)
 {
     // can be ConfigOptionDef::GUIType::color
-    m_disable_change_event = !change_event;
     const wxString clr_str(boost::any_cast<std::string>(value));
     auto field = dynamic_cast<wxColourPickerCtrl*>(window);
 
@@ -2155,8 +2042,6 @@ void ColourPicker::set_any_value(const boost::any &value, bool change_event)
         set_undef_value(field);
     else
         field->SetColour(clr);
-
-    m_disable_change_event = false;
 }
 
 boost::any& ColourPicker::get_value()
@@ -2254,13 +2139,16 @@ void GraphButton::BUILD()
             this->on_change_field();
         }
     }));
-    this->set_tooltip(current_value.serialize());
+    if (m_opt.default_value->is_enabled(m_opt_idx)) {
+        this->set_tooltip(current_value.serialize());
+    } else {
+        this->set_tooltip(wxString("Disabled (") + current_value.serialize() + ")");
+    }
 }
 
-void GraphButton::set_any_value(const boost::any &value, bool change_event)
+void GraphButton::set_internal_any_value(const boost::any &value, bool change_event)
 {
     // can be ConfigOptionDef::GUIType::color
-    m_disable_change_event = !change_event;
     if (this->m_opt.type == coGraphs && m_opt_idx >= 0) {
         assert(false); // shouldn't happen. or need to be tested
         std::vector<GraphData> graphs = boost::any_cast<std::vector<GraphData>>(value);
@@ -2272,7 +2160,6 @@ void GraphButton::set_any_value(const boost::any &value, bool change_event)
     } else if (this->m_opt.type == coGraph || this->m_opt.type == coGraphs) {
         m_value = current_value = boost::any_cast<GraphData>(value);
     }
-    m_disable_change_event = false;
 }
 
 boost::any& GraphButton::get_value()
@@ -2372,8 +2259,13 @@ void PointCtrl::BUILD()
 	// 	// recast as a wxWindow to fit the calling convention
 	sizer = dynamic_cast<wxSizer*>(temp);
 
-    this->set_tooltip(X + ", " + Y, x_textctrl);
-    this->set_tooltip(X + ", " + Y, y_textctrl);
+    if (m_opt.default_value->is_enabled(m_opt_idx)) {
+        this->set_tooltip(X + ", " + Y, x_textctrl);
+        this->set_tooltip(X + ", " + Y, y_textctrl);
+    } else {
+        this->set_tooltip(wxString("Disabled (") + X + ", " + Y + ")", x_textctrl);
+        this->set_tooltip(wxString("Disabled (") + X + ", " + Y + ")", y_textctrl);
+    }
 }
 
 void PointCtrl::msw_rescale()
@@ -2422,24 +2314,20 @@ void PointCtrl::propagate_value(text_ctrl* win)
         on_change_field();
 }
 
-void PointCtrl::set_vec2d_value(const Vec2d& value, bool change_event)
+void PointCtrl::set_vec2d_value(const Vec2d& value)
 {
-	m_disable_change_event = !change_event;
-
 	double val = value(0);
 	x_textctrl->SetValue(val - int(val) == 0 ? wxString::Format(_T("%i"), int(val)) : wxNumberFormatter::ToString(val, 2, wxNumberFormatter::Style_None));
 	val = value(1);
 	y_textctrl->SetValue(val - int(val) == 0 ? wxString::Format(_T("%i"), int(val)) : wxNumberFormatter::ToString(val, 2, wxNumberFormatter::Style_None));
-
-	m_disable_change_event = false;
 }
 
-void PointCtrl::set_any_value(const boost::any &value, bool change_event)
+void PointCtrl::set_internal_any_value(const boost::any &value, bool change_event)
 {
     // can be coPoint and coPoints (with idx)
     assert(m_opt.type == coPoint || (m_opt.type == coPoints && m_opt_idx >= 0));
     Vec2d pt = boost::any_cast<Vec2d>(value);
-    set_vec2d_value(pt, change_event);
+    set_vec2d_value(pt);
 }
 
 boost::any& PointCtrl::get_value()
@@ -2459,7 +2347,9 @@ boost::any& PointCtrl::get_value()
 		if (x > m_opt.max) x = m_opt.max;
 		if (m_opt.min > y) y = m_opt.min;
 		if (y > m_opt.max) y = m_opt.max;
-		set_vec2d_value(Vec2d(x, y), true);
+        assert(!m_disable_change_event);
+        m_disable_change_event = false;
+		set_vec2d_value(Vec2d(x, y));
 
 		show_error(m_parent, _L("Input value is out of range"));
 	}
@@ -2484,7 +2374,11 @@ void StaticText::BUILD()
 	// 	// recast as a wxWindow to fit the calling convention
 	window = dynamic_cast<wxWindow*>(temp);
 
-    this->set_tooltip(legend);
+    if (m_opt.default_value->is_enabled(m_opt_idx)) {
+        this->set_tooltip(legend);
+    } else {
+        this->set_tooltip(wxString("Disabled (") + legend + ")");
+    }
 }
 
 void StaticText::msw_rescale()
@@ -2551,11 +2445,10 @@ void SliderCtrl::BUILD()
 	m_sizer = dynamic_cast<wxSizer*>(temp);
 }
 
-void SliderCtrl::set_any_value(const boost::any &value, bool change_event)
+void SliderCtrl::set_internal_any_value(const boost::any &value, bool change_event)
 {
     // only with ConfigOptionDef::GUIType::slider: & coFloat or coInt
     assert(m_opt.gui_type == ConfigOptionDef::GUIType::slider && (m_opt.type == coFloat || m_opt.type == coInt));
-	m_disable_change_event = !change_event;
     if (m_opt.type == coFloat) {
         m_slider->SetValue(boost::any_cast<double>(value) * m_scale);
         double val = boost::any_cast<double>(get_value());
@@ -2565,8 +2458,6 @@ void SliderCtrl::set_any_value(const boost::any &value, bool change_event)
         int32_t val = boost::any_cast<int32_t>(get_value());
         m_textctrl->SetLabel(wxString::Format("%d", val));
     }
-
-	m_disable_change_event = false;
 }
 
 boost::any &SliderCtrl::get_value()

--- a/src/slic3r/GUI/GUI_ObjectSettings.cpp
+++ b/src/slic3r/GUI/GUI_ObjectSettings.cpp
@@ -128,7 +128,8 @@ bool ObjectSettings::update_settings_list()
             optgroup->title_width = 15;
             optgroup->sidetext_width = 5;
 
-            optgroup->m_on_change = [this, config](const t_config_option_key& opt_id, const boost::any& value) {
+            optgroup->m_on_change = [this, config](const t_config_option_key& opt_idv, bool enabled, const boost::any& value) {
+                                    assert(enabled);
                                     this->update_config_values(config);
                                     wxGetApp().obj_list()->changed_object(); };
 
@@ -161,10 +162,11 @@ bool ObjectSettings::update_settings_list()
             }
             optgroup->activate();
             for (auto& opt : cat.second)
-                optgroup->get_field(opt)->m_on_change = [optgroup](const std::string& opt_id, const boost::any& value) {
+                optgroup->get_field(opt)->m_on_change = [optgroup](const std::string& opt_id, bool enabled, const boost::any& value) {
+                    assert(enabled);
                     // first of all take a snapshot and then change value in configuration
                     wxGetApp().plater()->take_snapshot(format_wxstr(_L("Change Option %s"), opt_id));
-                    optgroup->on_change_OG(opt_id, value);
+                    optgroup->on_change_OG(opt_id, enabled, value);
                 };
 
             optgroup->reload_config();
@@ -251,7 +253,7 @@ void ObjectSettings::update_config_values(ModelConfig* config)
                 break;
         }
         if (field)
-            field->toggle(toggle);
+            field->toggle_widget_enable(toggle);
     };
 
     ConfigManipulation config_manipulation(load_config, toggle_field, nullptr, config);

--- a/src/slic3r/GUI/OG_CustomCtrl.hpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.hpp
@@ -68,15 +68,16 @@ class OG_CustomCtrl :public wxPanel
         wxCoord draw_mode_bmp(wxDC& dc, wxCoord v_pos);
         wxCoord draw_text      (wxDC& dc, wxPoint pos, const wxString& text, const wxString& tooltip, const wxColour* color, int width, bool is_url = false, bool align_right = false);
         wxPoint draw_blinking_bmp(wxDC& dc, wxPoint pos, bool is_blinking);
-        wxPoint draw_act_bmps(wxDC& dc, wxPoint pos, const wxBitmapBundle& bmp_undo_to_sys, const wxBitmapBundle& bmp_undo, bool is_blinking, size_t rect_id = 0);
+        wxPoint draw_act_bmps(wxDC& dc, wxPoint pos, const wxBitmapBundle& bmp_undo_to_sys, const wxBitmapBundle& bmp_undo, const wxBitmapBundle* bmp_enable, bool is_blinking, size_t rect_id = 0);
         wxCoord draw_edit_bmp(wxDC& dc, wxPoint pos, const wxBitmapBundle* bmp_edit);
         bool    launch_browser() const;
         bool    is_separator() const { return og_line.is_separator(); }
 
         std::vector<wxRect> rects_undo_icon;
         std::vector<wxRect> rects_undo_to_sys_icon;
+        std::vector<wxRect> rects_enable_icon;
         std::vector<std::pair<wxRect, wxString>> rects_tooltip;
-        std::vector<wxRect> rects_edit_icon;
+        std::vector<wxRect> rects_edit_icon; // should only work for full line, so the "vector" is useless.
     };
 
     std::vector<CtrlLine> ctrl_lines;

--- a/src/slic3r/GUI/OptionsGroup.hpp
+++ b/src/slic3r/GUI/OptionsGroup.hpp
@@ -191,10 +191,13 @@ public:
 		return nullptr;
     }
 
-	bool			set_value(const t_config_option_key& id, const boost::any& value, bool change_event = false) {
-							if (m_fields.find(id) == m_fields.end()) return false;
-							m_fields.at(id)->set_any_value(value, change_event);
-							return true;
+	bool			set_value(const t_config_option_key &id, const boost::any &value, bool enabled, bool change_event /*= false*/) {
+        if (auto it = m_fields.find(id); it != m_fields.end()) {
+            it->second->set_enable_bitmap_checked(enabled);
+            it->second->set_any_value(value, change_event);
+            return true;
+        }
+        return false;
     }
 	boost::any		get_value(const t_config_option_key& id) {
 							boost::any out; 
@@ -210,8 +213,8 @@ public:
 	void			set_name(const wxString& new_name) { stb->SetLabel(new_name); }
 	wxString		get_name() const { return stb->GetLabel(); }
 
-	inline void		enable() { for (auto& field : m_fields) field.second->enable(); }
-    inline void		disable() { for (auto& field : m_fields) field.second->disable(); }
+	inline void		enable() { for (auto& field : m_fields) field.second->widget_enable(); }
+    inline void		disable() { for (auto& field : m_fields) field.second->widget_disable(); }
 	void			set_grid_vgap(int gap) { m_grid_sizer->SetVGap(gap); }
 
     void            clear_fields_except_of(const std::vector<std::string> left_fields);
@@ -273,7 +276,7 @@ protected:
 	const t_field&		build_field(const Option& opt);
 
     virtual void		on_kill_focus(const std::string& opt_key) {};
-	virtual void		on_change_OG(const t_config_option_key& opt_id, const boost::any& value);
+	virtual void		on_change_OG(const t_config_option_key& opt_id, bool enable, const boost::any& value);
 	virtual void		back_to_initial_value(const std::string& opt_key) {}
 	virtual void		back_to_sys_value(const std::string& opt_key) {}
 
@@ -334,7 +337,7 @@ public:
 		append_single_option_line(option, path);
 	}
 
-	void		on_change_OG(const t_config_option_key& opt_id, const boost::any& value) override;
+	void		on_change_OG(const t_config_option_key& opt_id, bool enable, const boost::any& value) override;
 	void		back_to_initial_value(const std::string& opt_key) override;
 	void		back_to_sys_value(const std::string& opt_key) override;
 	void		back_to_config_value(const DynamicPrintConfig& config, const std::string& opt_key);
@@ -366,7 +369,7 @@ private:
     int                         m_config_type;
 
     // Change an option on m_config, possibly call ModelConfig::touch().
-	void 	change_opt_value(const t_config_option_key& opt_key, const boost::any& value, int opt_index = 0);
+	void 	change_opt_value(const t_config_option_key& opt_key, bool enable, const boost::any& value, int opt_index = 0);
 };
 
 //  Static text shown among the options.

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -435,8 +435,9 @@ void FreqChangedParams::init()
             m_og->set_config(config);
             m_og->hide_labels();
             m_og->m_on_change =
-                Tab::set_or_add(m_og->m_on_change, [tab_freq_fff, this](t_config_option_key opt_key, boost::any value)
+                Tab::set_or_add(m_og->m_on_change, [tab_freq_fff, this](t_config_option_key opt_key, bool enabled, boost::any value)
                                 {
+                                    assert(enabled); //TODO fix & test
                                     const Option *opt_def = this->m_og->get_option_def(opt_key);
                                     if (opt_def && !opt_def->opt.is_script) {
                                         tab_freq_fff->update_dirty();
@@ -531,7 +532,9 @@ void FreqChangedParams::init()
             m_og_sla->hide_labels();
             m_og_sla->m_on_change = Tab::set_or_add(m_og_sla->m_on_change, [tab_freq_sla,
                                                                             this](t_config_option_key opt_key,
+                                                                                  bool                enabled,
                                                                                   boost::any          value) {
+                assert(enabled);
                 Option opt = this->m_og_other[ptSLA]->create_option_from_def(opt_key);
                 if (!opt.opt.is_script) {
                     tab_freq_sla->update_dirty();
@@ -2736,8 +2739,8 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                         config.apply(loaded_printer_technology == ptFFF ?
                             static_cast<const ConfigBase&>(FullPrintConfig::defaults()) :
                             static_cast<const ConfigBase&>(SLAFullPrintConfig::defaults()));
-                        // Set all the nullable values in defaults to nils.
-                        config.null_nullables();
+                        // Disable all the optional values in defaults.
+                        config.disable_optionals();
                         // and place the loaded config over the base.
                         config += std::move(config_loaded);
                     }

--- a/src/slic3r/GUI/Preferences.hpp
+++ b/src/slic3r/GUI/Preferences.hpp
@@ -144,7 +144,7 @@ protected:
 								const std::string& opt_key,
 								const std::string& label,
 								const std::string& tooltip,
-								const ConfigOption* def_val,
+								ConfigOption* def_val,
 								std::initializer_list<std::pair<std::string_view, std::string_view>> enum_values,
 								ConfigOptionMode mode = ConfigOptionMode::comNone);
 

--- a/src/slic3r/GUI/PresetHints.cpp
+++ b/src/slic3r/GUI/PresetHints.cpp
@@ -97,25 +97,34 @@ void format_double_fan_min_speed(wxString& out, int min_speed, int default_speed
     }
 }
 
+int get_fan_speed(const Preset &preset_fil, const std::string &opt_key) {
+    const ConfigOption* option = preset_fil.config.option(opt_key);
+    // only consider the first idx, as it's the current one.
+    if (option->is_enabled(0)) {
+        return option->get_int(0);
+    }
+    return -1;
+}
+
 #define MIN_BUF_LENGTH  4096
 std::string PresetHints::cooling_description(const Preset &preset_fil, const Preset& preset_printer)
 {
     wxString out;
     // -1 is disable, 0 or 1 is "no fan". (and 1 will be "low fan" in the future)
     const int    min_fan_speed             = preset_printer.config.get_int("fan_printer_min_speed");
-    const int    default_fan_speed         = preset_fil.config.get_int("default_fan_speed");
+    const int    default_fan_speed         = get_fan_speed(preset_fil, "default_fan_speed");
     const int    max_fan_speed             = preset_fil.config.opt_int("max_fan_speed", 0);
-    const int    peri_fan_speed            = preset_fil.config.opt_int("perimeter_fan_speed", 0) == 1 ? 0 : preset_fil.config.get_int("perimeter_fan_speed");
-    const int    ext_peri_fan_speed        = preset_fil.config.opt_int("external_perimeter_fan_speed", 0) == 1 ? 0 : preset_fil.config.get_int("external_perimeter_fan_speed");
-    const int    infill_fan_speed          = preset_fil.config.opt_int("infill_fan_speed", 0) == 1 ? 0 : preset_fil.config.get_int("infill_fan_speed");
-    const int    solid_fan_speed           = preset_fil.config.opt_int("solid_infill_fan_speed", 0) == 1 ? 0 : preset_fil.config.get_int("solid_infill_fan_speed");
-    const int    top_fan_speed             = preset_fil.config.opt_int("top_fan_speed", 0) == 1 ? 0 : preset_fil.config.get_int("top_fan_speed");
-    const int    support_fan_speed         = preset_fil.config.opt_int("support_material_fan_speed", 0) == 1 ? 0 : preset_fil.config.get_int("support_material_fan_speed");
-    const int    supp_inter_fan_speed      = preset_fil.config.opt_int("support_material_interface_fan_speed", 0) == 1 ? 0 : preset_fil.config.get_int("support_material_interface_fan_speed");
-    const int    bridge_fan_speed          = preset_fil.config.opt_int("bridge_fan_speed", 0) == 1 ? 0 : preset_fil.config.get_int("bridge_fan_speed");
-    const int    internal_bridge_fan_speed = preset_fil.config.opt_int("internal_bridge_fan_speed", 0) == 1 ? 0 : preset_fil.config.get_int("internal_bridge_fan_speed");
-    const int    overhangs_fan_speed       = preset_fil.config.opt_int("overhangs_fan_speed", 0) == 1 ? 0 : preset_fil.config.get_int("overhangs_fan_speed");
-    const int    gap_fill_fan_speed        = preset_fil.config.opt_int("gap_fill_fan_speed", 0) == 1 ? 0 : preset_fil.config.get_int("gap_fill_fan_speed");
+    const int    peri_fan_speed            = get_fan_speed(preset_fil, "perimeter_fan_speed");
+    const int    ext_peri_fan_speed        = get_fan_speed(preset_fil, "external_perimeter_fan_speed");
+    const int    infill_fan_speed          = get_fan_speed(preset_fil, "infill_fan_speed");
+    const int    solid_fan_speed           = get_fan_speed(preset_fil, "solid_infill_fan_speed");
+    const int    top_fan_speed             = get_fan_speed(preset_fil, "top_fan_speed");
+    const int    support_fan_speed         = get_fan_speed(preset_fil, "support_material_fan_speed");
+    const int    supp_inter_fan_speed      = get_fan_speed(preset_fil, "support_material_interface_fan_speed");
+    const int    bridge_fan_speed          = get_fan_speed(preset_fil, "bridge_fan_speed");
+    const int    internal_bridge_fan_speed = get_fan_speed(preset_fil, "internal_bridge_fan_speed");
+    const int    overhangs_fan_speed       = get_fan_speed(preset_fil, "overhangs_fan_speed");
+    const int    gap_fill_fan_speed        = get_fan_speed(preset_fil, "gap_fill_fan_speed");
     const int    disable_fan_first_layers  = preset_fil.config.opt_int("disable_fan_first_layers", 0);
     const int    full_fan_speed_layer      = preset_fil.config.opt_int("full_fan_speed_layer", 0);
     const float  slowdown_below_layer_time = preset_fil.config.opt_float("slowdown_below_layer_time", 0);

--- a/src/slic3r/GUI/ScriptExecutor.cpp
+++ b/src/slic3r/GUI/ScriptExecutor.cpp
@@ -803,13 +803,22 @@ void as_ask_for_refresh()
     current_script->request_refresh();
 }
 
-bool as_is_enabled(std::string &key)
+bool as_is_widget_enabled(std::string &key)
 {
     Page *selected_page;
     Field *f = current_script->tab()->get_field(selected_page, key, -1);
     if (!f)
         return true;
-    return f->is_enabled();
+    return f->is_widget_enabled();
+}
+
+bool as_is_enabled(std::string &key, int idx)
+{
+    std::pair<const PresetCollection*, const ConfigOption*> result = get_coll(key);
+    const ConfigOption* opt = result.second;
+    if (opt == nullptr) //TODO check if  float, etc..
+        throw NoDefinitionExceptionEmitLog("is_enabled(): error, can't find string option " + key);
+    return opt->is_enabled(idx);
 }
 
 //function to reset a field
@@ -912,7 +921,8 @@ void ScriptContainer::init(const std::string& tab_key, Tab* tab)
             m_script_engine.get()->RegisterGlobalFunction("void back_initial_value(string &in)", WRAP_FN(as_back_initial_value), AngelScript::asCALL_GENERIC);
             m_script_engine.get()->RegisterGlobalFunction("void back_custom_initial_value(int, string &in)", WRAP_FN(as_back_custom_initial_value), AngelScript::asCALL_GENERIC);
             m_script_engine.get()->RegisterGlobalFunction("void ask_for_refresh()", WRAP_FN(as_ask_for_refresh), AngelScript::asCALL_GENERIC);
-            m_script_engine.get()->RegisterGlobalFunction("bool is_enabled(string &in)", WRAP_FN(as_is_enabled), AngelScript::asCALL_GENERIC);
+            m_script_engine.get()->RegisterGlobalFunction("bool is_enabled(string &in, int)", WRAP_FN(as_is_enabled), AngelScript::asCALL_GENERIC);
+            m_script_engine.get()->RegisterGlobalFunction("bool as_is_widget_enabled(string &in)", WRAP_FN(as_is_widget_enabled), AngelScript::asCALL_GENERIC);
 
 #else
             m_script_engine.get()->RegisterGlobalFunction("void print(string &in)",     AngelScript::asFUNCTION(as_print),          AngelScript::asCALL_CDECL);
@@ -957,7 +967,8 @@ void ScriptContainer::init(const std::string& tab_key, Tab* tab)
             m_script_engine.get()->RegisterGlobalFunction("void back_initial_value(string &in)",    AngelScript::asFUNCTION(as_back_initial_value), AngelScript::asCALL_CDECL);
             m_script_engine.get()->RegisterGlobalFunction("void back_custom_initial_value(int, string &in)",    AngelScript::asFUNCTION(as_back_custom_initial_value), AngelScript::asCALL_CDECL);
             m_script_engine.get()->RegisterGlobalFunction("void ask_for_refresh()",                 AngelScript::asFUNCTION(as_ask_for_refresh),    AngelScript::asCALL_CDECL);
-            m_script_engine.get()->RegisterGlobalFunction("bool is_enabled(string &in)",                        AngelScript::asFUNCTION(as_is_enabled), AngelScript::asCALL_CDECL);
+            m_script_engine.get()->RegisterGlobalFunction("bool is_enabled(string &in, int)",                        AngelScript::asFUNCTION(as_is_enabled), AngelScript::asCALL_CDECL);
+            m_script_engine.get()->RegisterGlobalFunction("bool as_is_widget_enabled(string &in)",                        AngelScript::asFUNCTION(as_is_widget_enabled), AngelScript::asCALL_CDECL);
 #endif
         }
 

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -155,7 +155,7 @@ public:
     void        refresh();
 	Field*		get_field(const t_config_option_key& opt_key, int opt_index = -1) const;
 	Line*		get_line(const t_config_option_key& opt_key);
-	bool		set_value(const t_config_option_key& opt_key, const boost::any& value);
+	bool		set_value(const t_config_option_key& opt_key, const boost::any& value, bool enabled);
 	ConfigOptionsGroupShp	new_optgroup(const wxString& title, bool no_title = false, bool is_tab_opt = true, Preset::Type type_override = Preset::Type::TYPE_INVALID);
 	const ConfigOptionsGroupShp	get_optgroup(const wxString& title) const;
 
@@ -287,6 +287,13 @@ protected:
 	ScalableBitmap 			m_bmp_value_revert;
 	// Bitmaps to be shown on the "Undo user changes" button next to each input field.
 	ScalableBitmap 			m_bmp_edit_value;
+	// Bitmaps to be shown on the "enable/disable" checkbox next to each input field that can be disabled.
+	ScalableBitmap 			m_bmp_on;
+	ScalableBitmap 			m_bmp_off;
+	ScalableBitmap 			m_bmp_on_disabled;
+	ScalableBitmap 			m_bmp_off_disabled;
+	ScalableBitmap 			m_bmp_on_focused;
+	ScalableBitmap 			m_bmp_off_focused;
     
     std::vector<ScalableButton*>	m_scaled_buttons = {};    
     std::vector<ScalableBitmap*>	m_scaled_bitmaps = {};    
@@ -482,7 +489,7 @@ public:
 	PresetCollection*	get_presets() { return m_presets; }
 	const PresetCollection* get_presets() const { return m_presets; }
 
-    bool            set_value(const t_config_option_key& opt_key, const boost::any& value);
+    bool            set_value(const t_config_option_key& opt_key, const boost::any& value, bool enabled);
 	void			on_value_change(const std::string& opt_key, const boost::any& value);
 
     void            update_wiping_button_visibility();
@@ -587,8 +594,8 @@ protected:
     BitmapComboBox* m_extruders_cb {nullptr};
     int             m_active_extruder {0};
 
-    void            create_line_with_near_label_widget(ConfigOptionsGroupShp optgroup, const std::string &opt_key, int opt_index = 0);
-    void            update_line_with_near_label_widget(ConfigOptionsGroupShp optgroup, const std::string &opt_key, int opt_index = 0, bool is_checked = true);
+    //void            create_line_with_near_label_widget(ConfigOptionsGroupShp optgroup, const std::string &opt_key, int opt_index = 0);
+    //void            update_line_with_near_label_widget(ConfigOptionsGroupShp optgroup, const std::string &opt_key, int opt_index = 0, bool is_checked = true);
     void            update_filament_overrides_page();
     void            create_extruder_combobox();
 	void 			update_volumetric_flow_preset_hints();

--- a/src/slic3r/GUI/wxExtensions.cpp
+++ b/src/slic3r/GUI/wxExtensions.cpp
@@ -456,18 +456,21 @@ wxBitmapBundle* get_bmp_bundle(const std::string& bmp_name_in, int width/* = 16*
         try {
             uint32_t color_int = Slic3r::GUI::wxGetApp().app_config->create_color(0.86f, 0.93f);
             changes.add("#ED6B21", color_int);
+            changes.add("#ED8D21", Slic3r::GUI::wxGetApp().app_config->create_color(0.5f, 0.93f));
             changes.add("#2172eb", color_int);
         }
         catch (std::exception /*e*/) {
         }
     } else {
         changes.add("#ED6B21", new_color.size() == 7 ? new_color : (std::string("#") + new_color));
+        //changes.add("#ED8D21", new_color.size() == 7 ? new_color : (std::string("#") + new_color));
         changes.add("#2172eb", new_color.size() == 7 ? new_color : (std::string("#") + new_color));
     }
     
-    if (Slic3r::GUI::wxGetApp().dark_mode()) {
-        changes.add("#808080", "#FFFFFF");
-    }
+    // already added in get_bmp_bundle(bmp_name_in, width, height, changes);
+    //if (Slic3r::GUI::wxGetApp().dark_mode()) {
+    //    changes.add("#808080", "#FFFFFF");
+    //}
 
     return get_bmp_bundle(bmp_name_in, width, height, changes);
 }


### PR DESCRIPTION
Hello 3D printing crew

I found the issue that the user was presenting in #4374. The problem was that the actual graph points data structure and `begin_idx`, `end_idx` usage were inconsistent in this function. As a result, all extrusion lengths above the max value we account for in the graph (~3.0mm in our case) were not interpolated and got a multiplication factor of 0 instead (the default in this function). I am not sure why the graph implementation works as it does but these changes make this function comply with how the graph and its data structures are currently implemented.

Below is the user's scenario as an example, working as expected.
![Screenshot from 2024-08-12 18-39-02](https://github.com/user-attachments/assets/4a6fe952-80c7-4e20-a991-18633ab7a1cc)

Additional fixes:
- I changed the function's default `y_value` to 1.0f, so the default behaviour leaves the extrusion value as it was.
- The equality comparison of extrusion length and the graph's data points should be done by checking how close to the value it is instead of equality, because of floating point arithmetics. (I)
- Some return instead of break statements to help with readability a bit.

(I): This can cause some discrepancies if we have 2 lines with very close but not equal lengths, as they will both get assigned the same extrusion factor. We could remove this check or make it compare from the left side only, but then again it is a small performance optimization. I leave this decision to the owner :)
(II): A question on the feature; should the feature's function not be monotonically non-decreasing? I personally cannot think of a case where a shorter line should extrude more than a longer one.