### PR TITLE
fix (jpge): rip out stdio.h include from jpge namespace

### DIFF
--- a/src/jpeg-compressor/jpge.cpp
+++ b/src/jpeg-compressor/jpge.cpp
@@ -30,9 +30,9 @@
 
 #include "jpge.h"
 
-#include <stdlib.h>
-#include <string.h>
-//#include <malloc.h> // not needed, even create bugs in macos
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #define JPGE_MAX(a,b) (((a)>(b))?(a):(b))
 #define JPGE_MIN(a,b) (((a)<(b))?(a):(b))
@@ -934,7 +934,6 @@ namespace jpge {
 	}
 
 	// Higher level wrappers/examples (optional).
-#include <stdio.h>
 
 	class cfile_stream : public output_stream
 	{


### PR DESCRIPTION
Fixes build errors with newer glibc-2.40. Standard library includes *should* not be inside non-global namespaces.

Changed includes to correct C++ variants of C headers. Drop commented out <malloc.h> because it's deprecated and non-standard anyway. The correct way to get malloc/free declarations is to include <cstdlib>.