### PR TITLE
Fix missing fan default speed in alternative GUI layout

### DIFF
--- a/resources/ui_layout/example/filament.ui
+++ b/resources/ui_layout/example/filament.ui
@@ -29,7 +29,7 @@ group:Print speed override
 
 page:Cooling:time
 group:Fan speed - default
-	setting:id$0:label$Run the fan at default speed when possible:fan_always_on
+	setting:id$0:default_fan_speed
 	line:Disable fan for the first
 		setting:id$0:width$5:label$_:sidetext_width$7:disable_fan_first_layers
 		setting:id$0:width$5:label_width$12:full_fan_speed_layer

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3821,7 +3821,7 @@ void PrintConfigDef::init_fff_params()
         "\nSet zero to disable.");
     def->min = 0;
     def->mode = comExpert | comSuSi;
-    def->set_default_value(new ConfigOptionFloat(1500));
+    def->set_default_value(new ConfigOptionFloat(0/*1500*/));
 
     def = this->add("max_fan_speed", coInts);
     def->label = L("Max");
@@ -4845,7 +4845,7 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->precision = 6;
     def->mode = comExpert | comSuSi;
-    def->set_default_value(new ConfigOptionFloatOrPercent(0.02, false));
+    def->set_default_value(new ConfigOptionFloatOrPercent(0/*0.02*/, false));
     def->aliases = {"min_length"};
 
     def = this->add("gcode_min_resolution", coFloatOrPercent);

--- a/src/libslic3r/TriangleMeshSlicer.cpp
+++ b/src/libslic3r/TriangleMeshSlicer.cpp
@@ -968,6 +968,9 @@ struct OpenPolyline {
 // Only connects segments crossing triangles of the same orientation.
 static void chain_lines_by_triangle_connectivity(IntersectionLines &lines, Polygons &loops, std::vector<OpenPolyline> &open_polylines)
 {
+    for(auto &loop : loops)
+        assert(!loop.points.front().coincides_with(loop.points.back()));
+
     // Build a map of lines by edge_a_id and a_id.
     std::vector<IntersectionLine*> by_edge_a_id;
     std::vector<IntersectionLine*> by_a_id;
@@ -1050,7 +1053,8 @@ static void chain_lines_by_triangle_connectivity(IntersectionLines &lines, Polyg
                     for(auto &loop : loops)
                         assert(!loop.points.front().coincides_with(loop.points.back()));
                     if (loop_pts.size() > 2) {
-                        assert(!loop_pts.front().coincides_with(loop_pts.back()));
+    for(auto &loop : loops)
+        assert(!loop.points.front().coincides_with(loop.points.back()));
                         loops.emplace_back(std::move(loop_pts));
                     }
                     #ifdef SLIC3R_TRIANGLEMESH_DEBUG

--- a/src/slic3r/GUI/ArrangeSettingsDialogImgui.cpp
+++ b/src/slic3r/GUI/ArrangeSettingsDialogImgui.cpp
@@ -140,6 +140,8 @@ void ArrangeSettingsDialogImgui::render(float pos_x, float pos_y)
 
 void ArrangeSettingsDialogImgui::set_arrange_settings(const DynamicPrintConfig &conf, PrinterTechnology tech)
 {
+    assert(conf.option("duplicate_distance") && conf.option("complete_objects") && conf.option("nozzle_diameter"));
+
     const ConfigOptionFloat *dd_opt = conf.option<ConfigOptionFloat>("duplicate_distance");
 
     if (dd_opt && dd_opt->value != 0) {
@@ -147,6 +149,7 @@ void ArrangeSettingsDialogImgui::set_arrange_settings(const DynamicPrintConfig &
         if (tech == ptSLA) {
             dist = dd_opt->value;
         } else if (tech == ptFFF) {
+    assert(conf.option("duplicate_distance") && conf.option("complete_objects") && conf.option("nozzle_diameter"));
             const ConfigOptionBool *co_opt = conf.option<ConfigOptionBool>("complete_objects");
             if (co_opt && co_opt->value) {
                 dist = float(min_object_distance(&conf, 0.) * 2);

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1857,6 +1857,12 @@ void GLCanvas3D::set_model(Model* model)
     m_selection.set_model(m_model);
 }
 
+void GLCanvas3D::set_arrange_settings(const DynamicPrintConfig &conf, PrinterTechnology tech)
+{
+
+    m_arrange_settings_dialog.set_arrange_settings(conf, tech);
+}
+
 void GLCanvas3D::bed_shape_changed()
 {
     refresh_camera_scene_box();

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -768,7 +768,7 @@ public:
     const Model* get_model() const { return m_model; }
 
     const arr2::ArrangeSettingsView * get_arrange_settings_view() const { return &m_arrange_settings_dialog; }
-    void set_arrange_settings(const DynamicPrintConfig& conf, PrinterTechnology tech) { m_arrange_settings_dialog.set_arrange_settings(conf, tech); }
+    void set_arrange_settings(const DynamicPrintConfig& conf, PrinterTechnology tech);
 
     const Selection& get_selection() const { return m_selection; }
     Selection& get_selection() { return m_selection; }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4199,7 +4199,7 @@ void Tab::load_current_preset()
 
     // apply duplicate_distance for print preset
     if (type() == Preset::TYPE_FFF_PRINT || type() == Preset::TYPE_SLA_PRINT) {
-        wxGetApp().mainframe->plater()->canvas3D()->set_arrange_settings(m_presets->get_edited_preset().config, m_presets->get_edited_preset().printer_technology());
+        //wxGetApp().mainframe->plater()->canvas3D()->set_arrange_settings(m_presets->get_edited_preset().config, m_presets->get_edited_preset().printer_technology());
     }
 
 //	m_undo_to_sys_btn->Enable(!preset.is_default);


### PR DESCRIPTION
Adds the missing `default_fan_speed` option and removes `fan_always_on` that was in its place but not doing anything,