### PR TITLE
MeshBoolean: fix GCC 14 compile error

### DIFF
--- a/src/libslic3r/MeshBoolean.cpp
+++ b/src/libslic3r/MeshBoolean.cpp
@@ -147,12 +147,12 @@ template<class _Mesh> TriangleMesh cgal_to_triangle_mesh(const _Mesh &cgalmesh)
     const auto &vertices = cgalmesh.vertices();
     int vsize = int(vertices.size());
 
-    for (auto &vi : vertices) {
+    for (auto vi : vertices) {
         auto &v = cgalmesh.point(vi); // Don't ask...
         its.vertices.emplace_back(to_vec3f(v));
     }
 
-    for (auto &face : faces) {
+    for (auto face : faces) {
         auto vtc = cgalmesh.vertices_around_face(cgalmesh.halfedge(face));
 
         int i = 0;


### PR DESCRIPTION
Otherwise the build fails with:
```
/build/source/src/libslic3r/MeshBoolean.cpp:161:16: error: non-const lvalue reference to type 'reference' (aka 'CGAL::SM_Vertex_index') cannot bind to a temporary of type 'reference' (aka 'CGAL::SM_Vertex_index')
  161 |     for (auto &vi : cgalmesh.vertices()) {
      |                ^  ~
/build/source/src/libslic3r/MeshBoolean.cpp:188:12: note: in instantiation of function template specialization 'Slic3r::MeshBoolean::cgal::cgal_to_triangle_mesh<CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick>>>' requested here
  188 |     return cgal_to_triangle_mesh(cgalmesh.m);
      |            ^
/nix/store/qg5xvm9icynvn84inj4g0z6zq9ibl06b-cgal-5.6.2/include/CGAL/Iterator_range.h:49:5: note: selected 'begin' function with iterator type 'CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick>>::Index_iterator<CGAL::SM_Vertex_index>'
   49 |   I begin() const
      |     ^
/build/source/src/libslic3r/MeshBoolean.cpp:166:16: error: non-const lvalue reference to type 'reference' (aka 'CGAL::SM_Face_index') cannot bind to a temporary of type 'reference' (aka 'CGAL::SM_Face_index')
  166 |     for (auto &face : cgalmesh.faces()) {
      |                ^    ~
/nix/store/qg5xvm9icynvn84inj4g0z6zq9ibl06b-cgal-5.6.2/include/CGAL/Iterator_range.h:49:5: note: selected 'begin' function with iterator type 'CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick>>::Index_iterator<CGAL::SM_Face_index>'
   49 |   I begin() const
      |     ^
3 warnings and 2 errors generated.
```