### PR TITLE
disable TBB_STRICT on Linux

### DIFF
--- a/deps/+TBB/TBB.cmake
+++ b/deps/+TBB/TBB.cmake
@@ -7,6 +7,7 @@ add_cmake_project(
         -DTBB_TEST=OFF
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON
         -DCMAKE_DEBUG_POSTFIX=_debug
+        $<$<PLATFORM_ID:Linux>:-DTBB_STRICT=OFF>
 )
 
 

--- a/resources/ui_layout/default/printer_fff.ui
+++ b/resources/ui_layout/default/printer_fff.ui
@@ -37,7 +37,7 @@ group:silent_mode_event:filename_format_event:Firmware
 	end_line
 	line:Processing limit
 		setting:max_gcode_per_second
-		setting:gcode_command_buffer
+#		setting:gcode_command_buffer
 	end_line
 	line:G2/G3 generation
 		setting:arc_fitting

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -177,6 +177,9 @@ void AppConfig::set_defaults()
         if (get("font_size").empty())
             set("font_size", "0");
 
+        if (get("side_panel_width").empty())
+            set("side_panel_width", "42");
+
         if (get("gcodeviewer_decimals").empty())
             set("gcodeviewer_decimals", "2");
 

--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -169,6 +169,8 @@ struct ExtrusionAttributes : ExtrusionFlow
 
     // What is the role / purpose of this extrusion?
     ExtrusionRole   role{ ExtrusionRole::None };
+    // set to true to prevent seam on this path.
+    bool no_seam = false;
     // OVerhangAttributes are currently computed for perimeters if dynamic overhangs are enabled. 
     // They are used to control fan and print speed in export.
     std::optional<OverhangAttributes> overhang_attributes;

--- a/src/libslic3r/ExtrusionRole.cpp
+++ b/src/libslic3r/ExtrusionRole.cpp
@@ -18,11 +18,10 @@ GCodeExtrusionRole extrusion_role_to_gcode_extrusion_role(ExtrusionRole role)
 {
     assert(role != ExtrusionRole::Mixed);
     if (role == ExtrusionRole::None)                return GCodeExtrusionRole::None;
-    if (role.is_perimeter()) {
-        return role.is_bridge() ? GCodeExtrusionRole::OverhangPerimeter :
-               role.is_external() ? GCodeExtrusionRole::ExternalPerimeter : 
-                                    GCodeExtrusionRole::Perimeter;
-    }
+    if (role == ExtrusionRole::ExternalPerimeter)   return GCodeExtrusionRole::ExternalPerimeter;
+    if (role == ExtrusionRole::Perimeter)           return GCodeExtrusionRole::Perimeter;
+    if (role == ExtrusionRole::OverhangExternalPerimeter) return GCodeExtrusionRole::OverhangPerimeter;
+    if (role == ExtrusionRole::OverhangPerimeter)   return GCodeExtrusionRole::OverhangPerimeter;
     if (role == ExtrusionRole::InternalInfill)      return GCodeExtrusionRole::InternalInfill;
     if (role == ExtrusionRole::SolidInfill)         return GCodeExtrusionRole::SolidInfill;
     if (role == ExtrusionRole::TopSolidInfill)      return GCodeExtrusionRole::TopSolidInfill;
@@ -118,8 +117,10 @@ std::string role_to_code(ExtrusionRole role)
         return L("IPeri");
     else if (role == ExtrusionRole::ExternalPerimeter)
         return L("EPeri");
-    else if (role.is_overhang())
+    else if (role == ExtrusionRole::OverhangPerimeter)
         return L("OPeri");
+    else if (role == ExtrusionRole::OverhangExternalPerimeter)
+        return L("OEPeri");
     else if (role == ExtrusionRole::InternalInfill)
         return L("IFill");
     else if (role == ExtrusionRole::SolidInfill)

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7936,7 +7936,7 @@ std::string GCodeGenerator::toolchange(uint16_t extruder_id, double print_z) {
     if (toolchange_gcode.empty() && m_writer.multiple_extruders) { // !custom_gcode_changes_tool(toolchange_gcode_parsed, m_writer.toolchange_prefix(), extruder_id) && !no_toolchange)
         gcode += toolchange_command;
     } else {
-        // user provided his own toolchange gcode, no need to do anything
+        // user provided his own toolchange gcode, no need to write anything
     }
     if (m_enable_cooling_markers) {
         gcode += ";_TOOLCHANGE " + std::to_string(extruder_id) + "\n";

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -581,7 +581,7 @@ private:
     void                      _extrude_line(std::string& gcode_str, const Line& line, const double e_per_mm, const std::string_view comment, ExtrusionRole role);
     void                      _extrude_line_cut_corner(std::string& gcode_str, const Line& line, const double e_per_mm, const std::string_view comment, Point& last_pos, const double path_width);
     std::string               _before_extrude(const ExtrusionPath &path, const std::string_view description, double speed = -1);
-    double_t                  _compute_speed_mm_per_sec(const ExtrusionPath &path_attrs, const double speed, double &fan_speed, std::string *comment);
+    double_t                  _compute_speed_mm_per_sec(const ExtrusionPath &path_attrs, const double speed, double &fan_speed, std::string *comment) const;
     std::pair<double, double> _compute_acceleration(const ExtrusionPath &path);
     std::string               _after_extrude(const ExtrusionPath &path);
     void print_machine_envelope(GCodeOutputStream &file, const Print &print);

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -196,6 +196,7 @@ namespace Slic3r {
             Wipe_End,
             Height,
             Width,
+            Seam,
             Layer_Change,
             Layer_Change_Travel,
             Layer_Change_Retraction_Start,
@@ -630,6 +631,7 @@ namespace Slic3r {
         float m_temperature;
         bool m_use_volumetric_e;
         SeamsDetector m_seams_detector;
+        std::optional<AxisCoords> m_seam;
         OptionsZCorrector m_options_z_corrector;
         size_t m_last_default_color_id;
         bool m_spiral_vase_active;

--- a/src/libslic3r/GCode/GCodeWriter.cpp
+++ b/src/libslic3r/GCode/GCodeWriter.cpp
@@ -212,7 +212,7 @@ std::string GCodeWriter::set_pressure_advance(double pa) const {
     std::string gcode;
     if (FLAVOR_IS(gcfKlipper)) {
         gcode = std::string("SET_PRESSURE_ADVANCE ADVANCE=") + to_string_nozero(pa, 4);
-        if (tool_id >= 0) {
+        if (tool_id >= 0 && !this->config.single_extruder_multi_material.value) {
             if (this->config.tool_name.size() > tool_id && !this->config.tool_name.get_at(tool_id).empty()) {
                 gcode += std::string(" EXTRUDER=") + this->config.tool_name.get_at(tool_id);
             } else {
@@ -508,10 +508,10 @@ std::string GCodeWriter::update_progress(uint32_t num, uint32_t tot, bool allow_
 
 std::string GCodeWriter::toolchange_prefix() const
 {
-    return FLAVOR_IS(gcfMakerWare) ? "M135 T" :
-           FLAVOR_IS(gcfSailfish) ? "M108 T" :
-           FLAVOR_IS(gcfKlipper) ? "ACTIVATE_EXTRUDER EXTRUDER=" :
-           "T";
+    return FLAVOR_IS(gcfMakerWare)                                                  ? "M135 T" :
+        FLAVOR_IS(gcfSailfish)                                                      ? "M108 T" :
+        FLAVOR_IS(gcfKlipper) && !this->config.single_extruder_multi_material.value ? "ACTIVATE_EXTRUDER EXTRUDER=" :
+                                                                                      "T";
 }
 
 std::string GCodeWriter::toolchange(uint16_t tool_id)
@@ -540,9 +540,11 @@ std::string GCodeWriter::toolchange(uint16_t tool_id)
 
     // return the toolchange command
     // if we are running a single-extruder setup, just set the extruder and return nothing
+    // no, still output TX to let the firmware know to change the filament
     std::ostringstream gcode;
     if (this->multiple_extruders) {
-        if (FLAVOR_IS(gcfKlipper)) {
+        // if klipper and not in single_extruder_multi_material, then you need to select the extruder by name.
+        if (FLAVOR_IS(gcfKlipper) && !this->config.single_extruder_multi_material.value) {
             //check if we can use the tool_name field or not
             if (tool_id > 0 && tool_id < this->config.tool_name.size() && !this->config.tool_name.get_at(tool_id).empty()
                 // NOTE: this will probably break if there's more than 10 tools, as it's relying on the
@@ -551,14 +553,15 @@ std::string GCodeWriter::toolchange(uint16_t tool_id)
                 gcode << this->toolchange_prefix() << this->config.tool_name.get_at(tool_id);
             } else {
                 gcode << this->toolchange_prefix() << "extruder";
-                if (tool_id > 0)
+                if (tool_id > 0) {
                     gcode << tool_id;
+                }
             }
         } else {
             gcode << this->toolchange_prefix() << tool_id;
         }
         if (this->config.gcode_comments)
-            gcode << " ; change extruder";
+            gcode << (this->config.single_extruder_multi_material.value ? " ; change filament" : " ; change extruder");
         gcode << "\n";
         gcode << this->reset_e(true);
     }

--- a/src/libslic3r/GCode/WipeTowerIntegration.cpp
+++ b/src/libslic3r/GCode/WipeTowerIntegration.cpp
@@ -115,7 +115,12 @@ std::string WipeTowerIntegration::append_tcr(GCodeGenerator &gcodegen, const Wip
     boost::replace_first(tcr_rotated_gcode, "[toolchange_gcode_from_wipe_tower_generator]", toolchange_gcode_str);
     boost::replace_first(tcr_rotated_gcode, "[deretraction_from_wipe_tower_generator]", deretraction_str);
     boost::replace_first(tcr_rotated_gcode, "{layer_z}", to_string_nozero(gcodegen.writer().get_position().z() + gcodegen.writer().config.z_offset.value, 4));
-    boost::replace_first(tcr_rotated_gcode, "[toolchange_gcode_disable_linear_advance]", gcodegen.writer().set_pressure_advance(0));
+    if (gcodegen.config().filament_pressure_advance.is_enabled(tcr.initial_tool)) {
+        boost::replace_first(tcr_rotated_gcode, "[toolchange_gcode_disable_linear_advance]",
+                             gcodegen.writer().set_pressure_advance(0));
+    } else {
+        boost::replace_first(tcr_rotated_gcode, "[toolchange_gcode_disable_linear_advance]\n","");
+    }
     if (gcodegen.config().filament_pressure_advance.is_enabled(new_extruder_id)) {
         boost::replace_first(tcr_rotated_gcode, "[toolchange_gcode_enable_linear_advance]",
                              gcodegen.writer().set_pressure_advance(gcodegen.config().filament_pressure_advance.get_at(new_extruder_id)));

--- a/src/libslic3r/MultiMaterialSegmentation.cpp
+++ b/src/libslic3r/MultiMaterialSegmentation.cpp
@@ -807,7 +807,7 @@ static std::vector<ExPolygons> extract_colored_segments(const std::vector<Colore
                 edge->color(VD_ANNOTATION::DELETED);
 
                 if (next_vertex.color() == VD_ANNOTATION::VERTEX_ON_CONTOUR || next_vertex.color() == VD_ANNOTATION::DELETED) {
-                    assert(next_vertex.color() == VD_ANNOTATION::VERTEX_ON_CONTOUR);
+                    // assert(next_vertex.color() == VD_ANNOTATION::VERTEX_ON_CONTOUR); ? and for DELETED ?
                     break;
                 }
 

--- a/src/libslic3r/MultiPoint.cpp
+++ b/src/libslic3r/MultiPoint.cpp
@@ -270,6 +270,122 @@ Points MultiPoint::visivalingam(const Points &pts, const double tolerance)
     return results;
 }
 
+/// <summary>
+/// douglas_peucker will keep only points that are more than 'tolerance' out of the current polygon.
+/// But when we want to ensure we don't have a segment less than min_length, it's not very usable.
+/// This one is more effective: it will keep all points like the douglas_peucker, and also all points 
+/// in-between that satisfies the min_length, ordered by their tolerance.
+/// Note: to have a all 360 points of a circle, then you need 'tolerance  <= min_length * (1-cos(1°)) ~= min_length * 0.000155'
+/// Note: douglas_peucker is bad for simplifying circles, as it will create uneven segments.
+/// </summary>
+/// <param name="pts"></param>
+/// <param name="tolerance"></param>
+/// <param name="min_length"></param>
+/// <returns></returns>
+Points MultiPoint::_douglas_peucker_plus(const Points& pts, const double tolerance, const double min_length)
+{
+    Points result_pts;
+    std::vector<size_t> result_idx;
+    const double tolerance_sq = tolerance * tolerance;
+    if (!pts.empty()) {
+        const Point* anchor = &pts.front();
+        size_t        anchor_idx = 0;
+        const Point* floater = &pts.back();
+        size_t        floater_idx = pts.size() - 1;
+        result_pts.reserve(pts.size());
+        result_pts.emplace_back(*anchor);
+        result_idx.reserve(pts.size());
+        result_idx.emplace_back(anchor_idx);
+        if (anchor_idx != floater_idx) {
+            assert(pts.size() > 1);
+            std::vector<size_t> dpStack;
+            dpStack.reserve(pts.size());
+            dpStack.emplace_back(floater_idx);
+            for (;;) {
+                double max_dist_sq = 0.0;
+                size_t furthest_idx = anchor_idx;
+                // find point furthest from line seg created by (anchor, floater) and note it
+                for (size_t i = anchor_idx + 1; i < floater_idx; ++i) {
+                    double dist_sq = Line::distance_to_squared(pts[i], *anchor, *floater);
+                    if (dist_sq > max_dist_sq) {
+                        max_dist_sq = dist_sq;
+                        furthest_idx = i;
+                    }
+                }
+                // remove point if less than tolerance
+                if (max_dist_sq <= tolerance_sq) {
+                    if (!floater->coincides_with_epsilon(result_pts.back())) {
+                        result_pts.emplace_back(*floater);
+                        result_idx.emplace_back(floater_idx);
+                    }
+                    anchor_idx = floater_idx;
+                    anchor = floater;
+                    assert(dpStack.back() == floater_idx);
+                    dpStack.pop_back();
+                    if (dpStack.empty())
+                        break;
+                    floater_idx = dpStack.back();
+                } else {
+                    floater_idx = furthest_idx;
+                    dpStack.emplace_back(floater_idx);
+                }
+                floater = &pts[floater_idx];
+            }
+        }
+        assert(result_pts.front() == pts.front());
+        assert(result_pts.back() == pts.back());
+
+        // add other points that are at not less than min_length dist of the other points.
+        //std::vector<double> distances;
+        for (size_t segment_idx = 0; segment_idx < result_idx.size()-1; segment_idx++) {
+            //distances.clear();
+            size_t start_idx = result_idx[segment_idx];
+            size_t end_idx = result_idx[segment_idx + 1];
+            if (end_idx - start_idx == 1) continue;
+            //create the list of distances
+            double sum = 0;
+            for (size_t i = start_idx; i < end_idx; i++) {
+                double dist = pts[i].distance_to(pts[i + 1]);
+                //distances.push_back(dist);
+                sum += dist;
+            }
+            if (sum < min_length * 2) continue;
+
+            Point* start_point = &result_pts[segment_idx];
+            Point* end_point = &result_pts[segment_idx + 1];
+
+            //use at least a point, even if it's not in the middle and sum ~= min_length * 2
+            double max_dist_sq = 0.0;
+            size_t furthest_idx = start_idx;
+            const double half_min_length_sq = min_length * min_length / 4;
+            // find point furthest from line seg created by (anchor, floater) and note it
+            for (size_t i = start_idx + 1; i < end_idx; ++i) {
+                if (start_point->distance_to_square(pts[i]) > half_min_length_sq && end_point->distance_to_square(pts[i]) > half_min_length_sq) {
+                    double dist_sq = Line::distance_to_squared(pts[i], *start_point, *end_point);
+                    if (dist_sq > max_dist_sq) {
+                        max_dist_sq = dist_sq;
+                        furthest_idx = i;
+                    }
+                }
+            }
+
+            if (furthest_idx > start_idx) {
+                //add this point
+                if (!floater->coincides_with_epsilon(result_pts[segment_idx + 1]) &&
+                    (segment_idx + 2 >= result_pts.size() ||
+                     !floater->coincides_with_epsilon(result_pts[segment_idx + 2]))) {
+                    result_idx.insert(result_idx.begin() + segment_idx + 1, furthest_idx);
+                    result_pts.insert(result_pts.begin() + segment_idx + 1, pts[furthest_idx]);
+                    //and retry to simplify it
+                    segment_idx--;
+                }
+            }
+        }
+    }
+    for(int i=1;i<result_pts.size();++i)
+        assert(!result_pts[i - 1].coincides_with_epsilon(result_pts[i]));
+    return result_pts;
+}
 #ifdef _DEBUG
 // to create a cpp multipoint to create test units.
 std::string MultiPoint::to_debug_string()

--- a/src/libslic3r/MultiPoint.hpp
+++ b/src/libslic3r/MultiPoint.hpp
@@ -223,6 +223,7 @@ public:
     static Points douglas_peucker(const Points &src, const coord_t tolerance) {
         return Slic3r::douglas_peucker(src, tolerance);
     }
+    static Points _douglas_peucker_plus(const Points& pts, const double tolerance, const double min_length);
     static Points visivalingam(const Points &src, const double tolerance);
 
     // Projection of a point onto the lines defined by the points.

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1895,7 +1895,6 @@ ExtrusionPaths PerimeterGenerator::create_overhangs_arachne(const Parameters &  
             std::max(params.ext_perimeter_flow.scaled_width() / 4, scale_t(params.print_config.resolution)),
             (is_external ? params.ext_perimeter_flow : params.perimeter_flow).scaled_width() / 10));
         //(const ThickPolyline& polyline, const ExtrusionRole role, const Flow& flow, const coord_t resolution_internal, const coord_t tolerance)
-        assert(paths.size() == 1);
         for (ExtrusionPath& path : paths) {
             //these variable_width paths aren't gapfill, they are proper perimeters
             path.set_can_reverse(is_loop);
@@ -5258,6 +5257,7 @@ void PerimeterGenerator::_merge_thin_walls(const Parameters &params, ExtrusionEn
     public:
         ChangeFlow(coordf_t resolution) : resolution_sqr(resolution * resolution) {}
         float percent_extrusion;
+        bool no_seam = false;
         std::vector<ExtrusionPath> paths;
         const Point* first_point = nullptr;
         coordf_t resolution_sqr;
@@ -5274,6 +5274,7 @@ void PerimeterGenerator::_merge_thin_walls(const Parameters &params, ExtrusionEn
                     travel.attributes_mutable().width = paths.back().width();
                     travel.attributes_mutable().height = paths.back().height();
                     travel.attributes_mutable().mm3_per_mm = 0;
+                    travel.attributes_mutable().no_seam = no_seam;
                     travel.polyline.append(last_point);
                     travel.polyline.append(pt);
                     paths.push_back(travel);
@@ -5291,6 +5292,7 @@ void PerimeterGenerator::_merge_thin_walls(const Parameters &params, ExtrusionEn
                         ExtrusionPath travel(ExtrusionAttributes(path.role(), ExtrusionFlow(0, path.width(), path.height())), false);
                         travel.polyline.append(*first_point);
                         travel.polyline.append(path.first_point());
+                        travel.attributes_mutable().no_seam = no_seam;
                         paths.push_back(travel);
                     }
                 }
@@ -5298,6 +5300,7 @@ void PerimeterGenerator::_merge_thin_walls(const Parameters &params, ExtrusionEn
             }
             path.attributes_mutable().mm3_per_mm *= percent_extrusion;
             path.attributes_mutable().width *= percent_extrusion;
+            path.attributes_mutable().no_seam = no_seam;
             paths.push_back(path);
         }
         virtual void use(ExtrusionPath3D &path3D) override { assert(false); /*shouldn't happen*/ }
@@ -5442,7 +5445,6 @@ void PerimeterGenerator::_merge_thin_walls(const Parameters &params, ExtrusionEn
             bool point_moved = false;
             if (first_part.size() <= 1 || first_part.length() < SCALED_EPSILON) {
                 assert(first_part.size() == 2);
-                assert(searcher.search_result.loop->paths.size() > 1);
                 //not long enough, move point to first point and destroy it
                 // idx_path_before will be replaced anyway by poly_after
                 assert(!searcher.search_result.loop->paths[idx_path_before].empty());
@@ -5524,6 +5526,9 @@ void PerimeterGenerator::_merge_thin_walls(const Parameters &params, ExtrusionEn
                 searcher.search_result.loop->visit(loop_assert_visitor);
 #endif
             } else {
+                //make these thin wall un-seamable
+                change_flow.no_seam = true;
+
                 //first add the return path
                 //ExtrusionEntityCollection tws_second = tws; // this does a deep copy
                 change_flow.first_point = &poly_after.front(); // end at the start of the next path

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -402,12 +402,12 @@ public:
     void slice();
 
     // Helpers to slice support enforcer / blocker meshes by the support generator.
-    std::vector<Polygons>       slice_support_volumes(const ModelVolumeType model_volume_type) const;
-    std::vector<Polygons>       slice_support_blockers() const { return this->slice_support_volumes(ModelVolumeType::SUPPORT_BLOCKER); }
-    std::vector<Polygons>       slice_support_enforcers() const { return this->slice_support_volumes(ModelVolumeType::SUPPORT_ENFORCER); }
+    std::vector<ExPolygons>     slice_support_volumes(const ModelVolumeType model_volume_type) const;
+    std::vector<ExPolygons>     slice_support_blockers() const { return this->slice_support_volumes(ModelVolumeType::SUPPORT_BLOCKER); }
+    std::vector<ExPolygons>     slice_support_enforcers() const { return this->slice_support_volumes(ModelVolumeType::SUPPORT_ENFORCER); }
 
     // Helpers to project custom facets on slices
-    void project_and_append_custom_facets(bool seam, EnforcerBlockerType type, std::vector<Polygons>& expolys) const;
+    std::vector<Polygons> project_and_append_custom_facets(bool seam, EnforcerBlockerType type) const;
 
     /// skirts if done per copy and not per platter
     const std::optional<ExtrusionEntityCollection>& skirt_first_layer() const { return m_skirt_first_layer; }

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1412,6 +1412,8 @@ bool PrintObject::invalidate_state_by_config_options(
                 || opt_key == "raft_layer_height"
                 || opt_key == "perimeter_generator"
                 || opt_key == "slice_closing_radius"
+                || opt_key == "slice_merge_dent"
+                || opt_key == "slice_merge_min_width"
                 || opt_key == "slicing_mode"
                 || opt_key == "support_material_contact_distance_type"
                 || opt_key == "support_material_contact_distance"
@@ -1611,6 +1613,7 @@ bool PrintObject::invalidate_state_by_config_options(
                 || opt_key == "first_layer_min_speed"
                 || opt_key == "first_layer_speed"
                 || opt_key == "first_layer_speed_over_raft"
+                || opt_key == "first_layer_strong_start"
                 || opt_key == "gap_fill_acceleration"
                 || opt_key == "gap_fill_flow_match_perimeter"
                 || opt_key == "gap_fill_speed"
@@ -5088,10 +5091,11 @@ static void project_triangles_to_slabs(SpanOfConstPtrs<Layer> layers, const inde
     }
 }
 
-void PrintObject::project_and_append_custom_facets(
-        bool seam, EnforcerBlockerType type, std::vector<Polygons>& out) const
+std::vector<Polygons> PrintObject::project_and_append_custom_facets(
+        bool seam, EnforcerBlockerType type) const
 {
-    for (const ModelVolume* mv : this->model_object()->volumes)
+    std::vector<Polygons> out;
+    for (const ModelVolume* mv : this->model_object()->volumes) {
         if (mv->is_model_part()) {
             const indexed_triangle_set custom_facets = seam
                     ? mv->seam_facets.get_facets_strict(*mv, type)
@@ -5116,6 +5120,8 @@ void PrintObject::project_and_append_custom_facets(
                 }
             }
         }
+    }
+    return out;
 }
 
 const Layer* PrintObject::get_layer_at_printz(coordf_t print_z) const {

--- a/src/libslic3r/SVG.cpp
+++ b/src/libslic3r/SVG.cpp
@@ -385,8 +385,11 @@ void SVG::export_expolygons(const char *path, const std::vector<std::pair<Slic3r
     bbox.merge(Point(std::max(bbox.min.x() + legend_size.x(), bbox.max.x()), bbox.max.y() + legend_size.y()));
 
     SVG svg(path, bbox);
-    for (const auto &exp_with_attr : expolygons_with_attributes)
-        svg.draw(exp_with_attr.first, exp_with_attr.second.color_fill, exp_with_attr.second.fill_opacity);
+    for (const auto &exp_with_attr : expolygons_with_attributes) {
+        if(exp_with_attr.second.fill_opacity > 0) {
+            svg.draw(exp_with_attr.first, exp_with_attr.second.color_fill, exp_with_attr.second.fill_opacity);
+        }
+    }
     for (const auto &exp_with_attr : expolygons_with_attributes) {
         if (exp_with_attr.second.outline_width > 0) {
             std::string color_contour = exp_with_attr.second.color_contour;

--- a/src/libslic3r/SVG.hpp
+++ b/src/libslic3r/SVG.hpp
@@ -112,6 +112,12 @@ public:
         ExPolygonAttributes() : ExPolygonAttributes("gray", "black", "blue") {}
         ExPolygonAttributes(const std::string &color) :
             ExPolygonAttributes(color, color, color) {}
+        ExPolygonAttributes(
+            const std::string &color,
+            const coord_t width,
+            float opacity = 0.5f) :
+            ExPolygonAttributes(color, color, color, width, opacity)
+            {}
 
         ExPolygonAttributes(
             const std::string &color_fill,

--- a/src/libslic3r/Support/SupportCommon.hpp
+++ b/src/libslic3r/Support/SupportCommon.hpp
@@ -25,7 +25,7 @@ void remove_bridges_from_contacts(
     const Layer         &lower_layer,
     const LayerRegion   &layerm,
     float                fw, 
-    Polygons            &contact_polygons);
+    ExPolygons          &contact_polygons);
 
 // Turn some of the base layers into base interface layers.
 // For soluble interfaces with non-soluble bases, print maximum two first interface layers with the base

--- a/src/libslic3r/Support/TreeModelVolumes.cpp
+++ b/src/libslic3r/Support/TreeModelVolumes.cpp
@@ -144,13 +144,13 @@ TreeModelVolumes::TreeModelVolumes(
             [&](const tbb::blocked_range<size_t> &range) {
             for (size_t layer_idx = range.begin(); layer_idx < range.end(); ++ layer_idx) {
                 if (layer_idx < coord_t(additional_excluded_areas.size()))
-                    append(m_anti_overhang[layer_idx], additional_excluded_areas[layer_idx]);
+                    append(m_anti_overhang[layer_idx], union_ex(additional_excluded_areas[layer_idx]));
     //          if (SUPPORT_TREE_AVOID_SUPPORT_BLOCKER)
     //              append(m_anti_overhang[layer_idx], storage.support.supportLayers[layer_idx].anti_overhang);
     //FIXME block wipe tower
     //          if (storage.primeTower.enabled)
     //              append(m_anti_overhang[layer_idx], layer_idx == 0 ? storage.primeTower.outer_poly_first_layer : storage.primeTower.outer_poly);
-                m_anti_overhang[layer_idx] = union_(m_anti_overhang[layer_idx]);
+                m_anti_overhang[layer_idx] = union_ex(m_anti_overhang[layer_idx]);
             }
         });
     }
@@ -519,7 +519,7 @@ void TreeModelVolumes::calculateCollision(const coord_t radius, const LayerIndex
                                 append(collisions, offset(union_ex(collision_areas_original), radius + required_range_x, ClipperLib::jtMiter, 1.2));
                             }
                         collisions = processing_last_mesh && layer_idx < int(anti_overhang.size()) ? 
-                                union_(collisions, offset(union_ex(anti_overhang[layer_idx]), radius, ClipperLib::jtMiter, 1.2)) : 
+                                union_(collisions, offset(anti_overhang[layer_idx], radius, ClipperLib::jtMiter, 1.2)) : 
                                 union_(collisions);
                         auto &dst = data[layer_idx];
                         if (processing_last_mesh) {
@@ -547,7 +547,7 @@ void TreeModelVolumes::calculateCollision(const coord_t radius, const LayerIndex
                         Polygons placable = diff(
                             // Inflate the surface to sit on by the separation distance to increase chance of a support being placed on a sloped surface.
                             offset(below, xy_distance), 
-                            layer_idx_below < int(anti_overhang.size()) ? union_(current, anti_overhang[layer_idx_below]) : current);
+                            layer_idx_below < int(anti_overhang.size()) ? union_(current, to_polygons(anti_overhang[layer_idx_below])) : current);
                         auto &dst     = data_placeable[layer_idx];
                         if (processing_last_mesh) {
                             if (! dst.empty())

--- a/src/libslic3r/Support/TreeModelVolumes.hpp
+++ b/src/libslic3r/Support/TreeModelVolumes.hpp
@@ -485,7 +485,7 @@ private:
     /*!
      * \brief Storage for areas that should be avoided, like support blocker or previous generated trees.
      */
-    std::vector<Polygons> m_anti_overhang;
+    std::vector<ExPolygons> m_anti_overhang;
     /*!
      * \brief Radii that can be ignored by ceilRadius as they will never be requested, sorted.
      */

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -25,6 +25,7 @@
 #include "../Polygon.hpp"
 #include "../Polyline.hpp"
 #include "../MutablePolygon.hpp"
+#include "../Thread.hpp"
 
 #include <cassert>
 #include <chrono>
@@ -194,77 +195,148 @@ static std::vector<std::pair<TreeSupportSettings, std::vector<size_t>>> group_me
 }
 #endif
 
+
+ExPolygons to_expolys(Polygons polys) {
+    ExPolygons ex_polys;
+    ex_polys.assign(polys.size(), ExPolygon());
+    for (size_t idx = 0; idx < polys.size(); ++idx) {
+        polys[idx].make_counter_clockwise();
+        ex_polys[idx].contour = polys[idx];
+    }
+    return ex_polys;
+}
+
 [[nodiscard]] static const std::vector<Polygons> generate_overhangs(const TreeSupportSettings &settings, const PrintObject &print_object, std::function<void()> throw_on_cancel)
 {
     const size_t num_raft_layers   = settings.raft_layers.size();
     const size_t num_object_layers = print_object.layer_count();
     const size_t num_layers        = num_object_layers + num_raft_layers;
-    std::vector<Polygons> out(num_layers, Polygons{});
+    std::vector<ExPolygons> out(num_layers, ExPolygons{});
 
     const PrintConfig       &print_config           = print_object.print()->config();
     const PrintObjectConfig &config                 = print_object.config();
     const bool               support_auto           = config.support_material.value && config.support_material_auto.value;
     const int                support_enforce_layers = config.support_material_enforce_layers.value;
-    std::vector<Polygons>    enforcers_layers{ print_object.slice_support_enforcers() };
-    std::vector<Polygons>    blockers_layers{ print_object.slice_support_blockers() };
-    print_object.project_and_append_custom_facets(false, EnforcerBlockerType::ENFORCER, enforcers_layers);
-    print_object.project_and_append_custom_facets(false, EnforcerBlockerType::BLOCKER, blockers_layers);
+    std::vector<ExPolygons>  enforcers_layers{ print_object.slice_support_enforcers() };
+    std::vector<ExPolygons>  blockers_layers{ print_object.slice_support_blockers() };
+    const std::vector<Polygons>    enforcers_custom_facets = print_object.project_and_append_custom_facets(false, EnforcerBlockerType::ENFORCER);
+    const std::vector<Polygons>    blockers_custom_facets = print_object.project_and_append_custom_facets(false, EnforcerBlockerType::BLOCKER);
     const int                support_threshold      = config.support_material_threshold.value;
     const bool               support_threshold_auto = support_threshold == 0;
     // +1 makes the threshold inclusive
     double                   tan_threshold          = support_threshold_auto ? 0. : tan(M_PI * double(support_threshold + 1) / 180.);
     //FIXME this is a fudge constant!
     auto                     enforcer_overhang_offset = scaled<double>(config.support_tree_tip_diameter.value);
+    const size_t num_overhang_layers = support_auto ?
+        num_object_layers :
+        std::min(num_object_layers,
+                 std::max(size_t(support_enforce_layers),
+                          std::max(enforcers_layers.size(), enforcers_custom_facets.size())));
 
-    size_t num_overhang_layers = support_auto ? num_object_layers : std::min(num_object_layers, std::max(size_t(support_enforce_layers), enforcers_layers.size()));
-    tbb::parallel_for(tbb::blocked_range<LayerIndex>(1, num_overhang_layers),
-        [&print_object, &config, &print_config, &enforcers_layers, &blockers_layers, 
+    assert(enforcers_custom_facets.size() == num_overhang_layers || enforcers_custom_facets.empty());
+    assert(blockers_custom_facets.size() == num_overhang_layers || blockers_custom_facets.empty());
+    if (enforcers_layers.empty() || enforcers_layers.size() < num_overhang_layers)
+        enforcers_layers.resize(num_overhang_layers);
+    if (blockers_layers.empty() || blockers_layers.size() < num_overhang_layers)
+        blockers_layers.resize(num_overhang_layers);
+    assert(enforcers_layers.size() == num_overhang_layers);
+    assert(blockers_layers.size() == num_overhang_layers);
+
+    Slic3r::not_parallel_for(1, num_overhang_layers,
+        [&print_object, &config, &print_config, &enforcers_layers, &enforcers_custom_facets, &blockers_layers, &blockers_custom_facets,
          support_auto, support_enforce_layers, support_threshold_auto, tan_threshold, enforcer_overhang_offset, num_raft_layers, &throw_on_cancel, &out]
-        (const tbb::blocked_range<LayerIndex> &range) {
-        for (LayerIndex layer_id = range.begin(); layer_id < range.end(); ++ layer_id) {
+        //(const tbb::blocked_range<LayerIndex> &range) {
+        //for (LayerIndex layer_id = range.begin(); layer_id < range.end(); ++ layer_id) {
+        (const size_t layer_id) { {
             const Layer   &current_layer  = *print_object.get_layer(layer_id);
             const Layer   &lower_layer    = *print_object.get_layer(layer_id - 1);
             // Full overhangs with zero lower_layer_offset and no blockers applied.
-            Polygons       raw_overhangs;
+            ExPolygons     raw_overhangs;
             bool           raw_overhangs_calculated = false;
             // Final overhangs.
-            Polygons       overhangs;
+            ExPolygons     overhangs;
             // For how many layers full overhangs shall be supported.
             const bool     enforced_layer = layer_id < support_enforce_layers;
             if (support_auto || enforced_layer) {
                 float lower_layer_offset;
-                if (enforced_layer)
+                if (enforced_layer) {
                     lower_layer_offset = 0;
-                else if (support_threshold_auto) {
+                } else if (support_threshold_auto) {
                     float external_perimeter_width = 0;
-                    for (const LayerRegion *layerm : lower_layer.regions())
+                    for (const LayerRegion *layerm : lower_layer.regions()) {
                         external_perimeter_width += layerm->flow(frExternalPerimeter).scaled_width();
+                    }
                     external_perimeter_width /= lower_layer.region_count();
                     lower_layer_offset = float(0.5 * external_perimeter_width);
-                } else
+                } else {
                     lower_layer_offset = scaled<float>(lower_layer.height / tan_threshold);
+                }
                 overhangs = lower_layer_offset == 0 ?
-                    diff(current_layer.lslices(), lower_layer.lslices()) :
-                    diff(current_layer.lslices(), offset(lower_layer.lslices(), lower_layer_offset));
+                    diff_ex(current_layer.lslices(), lower_layer.lslices()) :
+                    diff_ex(current_layer.lslices(), offset_ex(lower_layer.lslices(), lower_layer_offset));
                 if (lower_layer_offset == 0) {
                     raw_overhangs = overhangs;
                     raw_overhangs_calculated = true;
                 }
-                if (! (enforced_layer || blockers_layers.empty() || blockers_layers[layer_id].empty()))
-                    overhangs = diff(overhangs, blockers_layers[layer_id], ApplySafetyOffset::Yes);
+#ifdef TREESUPPORT_DEBUG_SVG
+                if (!overhangs.empty()) {
+                    ExPolygons block;
+                    append(block, blockers_layers[layer_id]);
+                    if (!blockers_custom_facets.empty())
+                        append(block, union_ex(blockers_custom_facets[layer_id]));
+                    SVG::export_expolygons(debug_out_path("%d-overhangs_areas.svg", layer_id),
+                                           {
+                                               {current_layer.lslices(), {"gray", scale_t(0.015)}},
+                                               {(overhangs), {"yellow", scale_t(0.011)}},
+                                               {(block), {"red", scale_t(0.009)}},
+                                               {diff_ex(overhangs, block), {"blue", scale_t(0.006)}},
+                                               {diff_ex(overhangs, block, ApplySafetyOffset::Yes),
+                                                {"purple", scale_t(0.003)}},
+                                           });
+                }
+#endif // TREESUPPORT_DEBUG_SVG
+                assert(blockers_layers.size() == blockers_custom_facets.size() || blockers_custom_facets.empty());
+                if (!enforced_layer) {
+                    if (!blockers_custom_facets.empty() && !blockers_custom_facets[layer_id].empty()) {
+                        append(blockers_layers[layer_id], union_ex(blockers_custom_facets[layer_id]));
+                    }
+                    if (!blockers_layers[layer_id].empty()) {
+                        overhangs = diff_ex(overhangs, blockers_layers[layer_id] /*, ApplySafetyOffset::Yes //note: safety offset o*/);
+                        // just to be safe
+                        // overhangs = offset2_ex(overhangs, - EPSILON *10, EPSILON *10);
+                    }
+                }
                 if (config.dont_support_bridges) {
                     for (const LayerRegion *layerm : current_layer.regions())
-                        remove_bridges_from_contacts(print_config, lower_layer, *layerm, 
-                            float(layerm->flow(frExternalPerimeter).scaled_width()), overhangs);
+                        remove_bridges_from_contacts(print_config, lower_layer, *layerm,
+                                                     float(layerm->flow(frExternalPerimeter).scaled_width()),
+                                                     overhangs);
                 }
             }
+#ifdef TREESUPPORT_DEBUG_SVG
+            if (!overhangs.empty()) {
+                SVG::export_expolygons(debug_out_path("%d-overhangs_without_bridges_areas.svg", layer_id),
+                                       {
+                                           {current_layer.lslices(), {"gray", scale_t(0.05)}},
+                                           {union_ex(overhangs), {"yellow", scale_t(0.045)}},
+                                       });
+            }
+#endif // TREESUPPORT_DEBUG_SVG
             //check_self_intersections(overhangs, "generate_overhangs1");
-            if (! enforcers_layers.empty() && ! enforcers_layers[layer_id].empty()) {
+            assert(enforcers_custom_facets.size() == enforcers_layers.size() || enforcers_custom_facets.empty());
+            if (!enforcers_custom_facets.empty() && !enforcers_custom_facets[layer_id].empty()) {
+                append(enforcers_layers[layer_id], union_ex(enforcers_custom_facets[layer_id]));
+            }
+            if (!enforcers_layers[layer_id].empty()) {
                 // Has some support enforcers at this layer, apply them to the overhangs, don't apply the support threshold angle.
                 //enforcers_layers[layer_id] = union_(enforcers_layers[layer_id]);
                 //check_self_intersections(enforcers_layers[layer_id], "generate_overhangs - enforcers");
                 //check_self_intersections(to_polygons(lower_layer.lslices()), "generate_overhangs - lowerlayers");
-                if (Polygons enforced_overhangs = intersection(raw_overhangs_calculated ? raw_overhangs : diff(current_layer.lslices(), lower_layer.lslices()), enforcers_layers[layer_id] /*, ApplySafetyOffset::Yes */);
+                    if (ExPolygons enforced_overhangs =
+                            intersection_ex(raw_overhangs_calculated ?
+                                                raw_overhangs :
+                                                diff_ex(current_layer.lslices(), lower_layer.lslices()),
+                                            enforcers_layers[layer_id] /*, ApplySafetyOffset::Yes */);
                     ! enforced_overhangs.empty()) {
                     //FIXME this is a hack to make enforcers work on steep overhangs.
                     //check_self_intersections(enforced_overhangs, "generate_overhangs - enforced overhangs1");
@@ -272,7 +344,7 @@ static std::vector<std::pair<TreeSupportSettings, std::vector<size_t>>> group_me
                     //check_self_intersections(to_polygons(union_ex(enforced_overhangs)), "generate_overhangs - enforced overhangs11");
                     //check_self_intersections(offset(union_ex(enforced_overhangs),
                     //FIXME enforcer_overhang_offset is a fudge constant!
-                    enforced_overhangs = diff(offset(union_ex(enforced_overhangs), enforcer_overhang_offset),
+                    enforced_overhangs = diff_ex(offset_ex(enforced_overhangs, enforcer_overhang_offset),
                         lower_layer.lslices());
 #ifdef TREESUPPORT_DEBUG_SVG
 //                    if (! intersecting_edges(enforced_overhangs).empty()) 
@@ -283,12 +355,30 @@ static std::vector<std::pair<TreeSupportSettings, std::vector<size_t>>> group_me
                               { { lower_layer.lslices() },        { "lower_layer.lslices", "gray", 0.5f } },
                               { { union_ex(enforced_overhangs) }, { "enforced_overhangs", "red",  "black", "", scaled<coord_t>(0.1f), 0.5f } } });
                     }
+                    SVG::export_expolygons(
+                        debug_out_path("%d-forced-overhangs.svg", current_layer.id()),
+                        {
+                            {current_layer.lslices(), {"gray", scale_t(0.05)}},
+                            {(overhangs), {"yellow", scale_t(0.045)}},
+                            {(enforced_overhangs), {"blue", scale_t(0.035)}},
+                            {(overhangs.empty() ? std::move(enforced_overhangs) : union_ex(overhangs, enforced_overhangs)), {"green", scale_t(0.025)}},
+                        }
+                    );
 #endif // TREESUPPORT_DEBUG_SVG
                     //check_self_intersections(enforced_overhangs, "generate_overhangs - enforced overhangs2");
-                    overhangs = overhangs.empty() ? std::move(enforced_overhangs) : union_(overhangs, enforced_overhangs);
+                    overhangs = overhangs.empty() ? std::move(enforced_overhangs) : union_ex(overhangs, enforced_overhangs);
                     //check_self_intersections(overhangs, "generate_overhangs - enforcers");
                 }
-            }   
+            }
+#ifdef TREESUPPORT_DEBUG_SVG
+            if (!overhangs.empty()) {
+                SVG::export_expolygons(debug_out_path("%d-overhangs_register.svg", layer_id),
+                                       {
+                                           {current_layer.lslices(), {"gray", scale_t(0.05)}},
+                                           {(overhangs), /*ExPolygonAttributes*/ {"red", scale_t(0.045)}},
+                                       });
+            }
+#endif // TREESUPPORT_DEBUG_SVG
             out[layer_id + num_raft_layers] = std::move(overhangs);
             throw_on_cancel();
         }
@@ -310,7 +400,7 @@ static std::vector<std::pair<TreeSupportSettings, std::vector<size_t>>> group_me
                 //FIXME this is a hack to make enforcers work on steep overhangs.
                 //FIXME enforcer_overhang_offset is a fudge constant!
                 enforced_overhangs = offset(union_ex(enforced_overhangs), enforcer_overhang_offset);
-                overhangs = overhangs.empty() ? std::move(enforced_overhangs) : union_(overhangs, enforced_overhangs);
+                overhangs = overhangs.empty() ? std::move(enforced_overhangs) : union_ex(overhangs, enforced_overhangs);
             }
         }   
 #endif
@@ -318,8 +408,27 @@ static std::vector<std::pair<TreeSupportSettings, std::vector<size_t>>> group_me
         throw_on_cancel();
     }
 #endif
+#ifdef TREESUPPORT_DEBUG_SVG
+    for (size_t lidx =0;lidx < out.size(); lidx++) {
+        ExPolygons &overhang = out[lidx];
+        if(overhang.empty()) continue;
+        assert( lidx < print_object.layers().size());
+        ExPolygons slice = print_object.layers()[lidx]->lslices();
+        SVG::export_expolygons(
+            debug_out_path("%d-overhangs_areas_final.svg", lidx),
+            {
+                {slice, {"gray", scale_t(0.05)}},
+                {(overhang), /*ExPolygonAttributes*/{"red", scale_t(0.045)}},
+            }
+        );
+    }
+#endif // TREESUPPORT_DEBUG_SVG
 
-    return out;
+    std::vector<Polygons> polysout;
+    for (ExPolygons expolys : out) {
+        polysout.push_back(to_polygons(expolys));
+    }
+    return polysout;
 }
 
 /*!
@@ -3455,8 +3564,7 @@ static void generate_support_areas(Print &print,
 
         //FIXME generating overhangs just for the furst mesh of the group.
         assert(processing.second.size() == 1);
-        std::vector<Polygons>        overhangs = generate_overhangs(config, *print.get_object(processing.second.front()), throw_on_cancel);
-
+        std::vector<Polygons>      overhangs = generate_overhangs(config, *print.get_object(processing.second.front()), throw_on_cancel);
         // ### Precalculate avoidances, collision etc.
         size_t num_support_layers = precalculate(print, overhangs, processing.first, processing.second, volumes, throw_on_cancel);
         bool   has_support = num_support_layers > 0;

--- a/src/libslic3r/TriangleMeshSlicer.cpp
+++ b/src/libslic3r/TriangleMeshSlicer.cpp
@@ -1079,7 +1079,7 @@ static void chain_lines_by_triangle_connectivity(IntersectionLines &lines, Polyg
                 next_line->edge_a_id, next_line->edge_b_id, next_line->a_id, next_line->b_id,
                 next_line->a.x, next_line->a.y, next_line->b.x, next_line->b.y);
             */
-            assert(last_line->b == next_line->a);
+            assert((last_line->b - next_line->a).norm() < 10);
             loop_pts.emplace_back(next_line->a);
             last_line = next_line;
             next_line->set_skip();

--- a/src/platform/osx/BuildMacOSImage.sh.in
+++ b/src/platform/osx/BuildMacOSImage.sh.in
@@ -76,10 +76,38 @@ done
         # copy bin and do not let it lower case
         cp -f bin/@SLIC3R_APP_CMD@ pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/MacOS/@SLIC3R_APP_KEY@
         chmod u+x pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/MacOS/@SLIC3R_APP_KEY@
-        cp /usr/local/opt/zstd/lib/libzstd.1.dylib pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/MacOS/libzstd.1.dylib
-
+        
+        echo "otool -L exefile:"
+        otool -L pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/MacOS/@SLIC3R_APP_KEY@
+        echo "END otool"
+        
+        #copy libzstd
+        ZSDT_FILE=
+        echo "libzstd:\n"
+        ls -al /opt/homebrew/opt/zstd/lib/libzstd*.dylib
+        ls -al /usr/local/opt/zstd/lib/libzstd*.dylib
+        ZSDT_PATH=$(ls -v /usr/local/opt/zstd/lib/libzstd.1.*.dylib | tail -n 1)
+        if [ -z "${ZSDT_FILE}" ]
+        then
+            # try with homebrew
+            ZSDT_PATH=$(ls -v /opt/homebrew/opt/zstd/lib/libzstd.1.*.dylib | tail -n 1)
+        fi
+        ZSTD_FILE=$(basename ${ZSDT_PATH})
+        echo "zstd var:'"$ZSDT_PATH"' : "$ZSTD_FILE;
+        cp $ZSDT_PATH pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/Frameworks/$ZSTD_FILE
+        ls -al pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/Frameworks/
+        install_name_tool -change $ZSDT_PATH @executable_path/../Frameworks/$ZSTD_FILE pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/MacOS/@SLIC3R_APP_KEY@
+        install_name_tool -change /opt/homebrew/opt/zstd/lib/libzstd.1.dylib @executable_path/../Frameworks/$ZSTD_FILE pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/MacOS/@SLIC3R_APP_KEY@
+        install_name_tool -change /usr/local/opt/zstd/lib/libzstd.1.dylib @executable_path/../Frameworks/$ZSTD_FILE pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/MacOS/@SLIC3R_APP_KEY@
+        
+        echo "otool -L exefile now:"
+        otool -L pack/@SLIC3R_APP_KEY@/@SLIC3R_APP_KEY@.app/Contents/MacOS/@SLIC3R_APP_KEY@
+        echo "END otool"
+        
 #     } &> $ROOT/Build.log # Capture all command output
     echo -e "\n ... done\n"
+
+DMG_NAME=@SLIC3R_APP_KEY@${VERSION_NUMBER}-$OS_NAME.dmg
 
 if [[ -n "$BUILD_IMAGE" ]]
 then
@@ -91,26 +119,28 @@ echo -e "\n[9/9] Creating .tgz and DMG Image for distribution..."
 
     # create dmg
     hdiutil create -ov -fs HFS+ -volname "@SLIC3R_APP_KEY@" -srcfolder "pack/@SLIC3R_APP_KEY@" temp.dmg
-    hdiutil convert temp.dmg -format UDZO -o @SLIC3R_APP_KEY@${VERSION_NUMBER}-$OS_NAME.dmg
+    hdiutil convert temp.dmg -format UDZO -o $DMG_NAME
     rm -f temp.dmg
-    popd
+    
   } &> $ROOT/Build.log # Capture all command output
 
   # check if evrything went well
-  if [ -e $OS_NAME.dmg ]; then
+  if [ -e $OS_NAME ]; then
       echo -e "\n ... done\n"
   else
       # something went wrong, publish log
       echo -e "\n ... fail\n"
+      ls -al
       cat $ROOT/Build.log
   fi
 fi
 
-if [[ -e $OS_NAME.dmg ]]
+if [[ -e $DMG_NAME ]]
 then
-
+  echo -e "\nsuccess, returning.\n"
+  exit 0
 else
-echo -e "\n[9/9 (bis)] Creating .tgz and DMG Image for distribution... again"
+  echo -e "\n[9/9 (bis)] Creating .tgz and DMG Image for distribution... again"
   {
     echo killing...; sudo pkill -9 XProtect >/dev/null || true;
     echo waiting...; while pgrep XProtect; do sleep 3; done;
@@ -120,18 +150,19 @@ echo -e "\n[9/9 (bis)] Creating .tgz and DMG Image for distribution... again"
 
     # create dmg
     hdiutil create -ov -fs HFS+ -volname "@SLIC3R_APP_KEY@" -srcfolder "pack/@SLIC3R_APP_KEY@" temp.dmg
-    hdiutil convert temp.dmg -format UDZO -o @SLIC3R_APP_KEY@${VERSION_NUMBER}-$OS_NAME.dmg
+    hdiutil convert temp.dmg -format UDZO -o $DMG_NAME
     rm -f temp.dmg
-    popd
   } &> $ROOT/Build.log # Capture all command output
 
   # check if evrything went well
-  if [ -e $OS_NAME.dmg ]; then
+  if [ -e $DMG_NAME ]; then
       echo -e "\n ... done\n"
   else
       # something went wrong, publish log
       echo -e "\n ... fail\n"
+      ls -al
       cat $ROOT/Build.log
+      exit 1 # terminate and indicate error
   fi
 fi
 

--- a/src/slic3r/GUI/DoubleSlider.cpp
+++ b/src/slic3r/GUI/DoubleSlider.cpp
@@ -802,8 +802,8 @@ wxString Control::get_label(int tick, LabelType label_type/* = ltHeightWithLayer
         //assert(m_layers_times.size() == m_values.size() - 1 || m_layers_times.size()  == m_values.size() || m_layers_times.empty());
         //assert(m_layers_values.empty());
     }
-    const size_t layer_number = is_preview_not_gcode ? value + 1 : value;
-    const size_t time_idx = is_preview_not_gcode ? value : value - 1;
+    const size_t layer_number = is_preview_not_gcode ? value : value + 1;
+    const size_t time_idx = is_preview_not_gcode ? value : value;
 
     // When "Print Settings -> Multiple Extruders -> No sparse layer" is enabled, then "Smart" Wipe Tower is used for wiping.
     // As a result, each layer with tool changes is splited for min 3 parts: first tool, wiping, second tool ...

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -679,9 +679,15 @@ void MenuFactory::append_menu_items_add_volume(MenuType menu_type)
             menu->Destroy(item_id);
     }
 
-    // Update "Height range Modifier" item (delete old & create new)
-    if (const auto range_id = menu->FindItem(_L("Height range Modifier")); range_id != wxNOT_FOUND)
-        menu->Destroy(range_id);
+    //also destroy combined menus & the ones taht aren't in ADD_VOLUME_MENU_ITEMS
+    wxString combined_support_str = _L("Add support blocker/enforcer");
+    wxString combined_brim_str = _L("Add Brim patch/blocker");
+    wxString combined_seam_str  =_L("Add seam position");
+    for (const wxString &item_name : {combined_support_str, combined_brim_str, combined_seam_str}) {
+        int item_id = menu->FindItem(item_name);
+        if (item_id != wxNOT_FOUND)
+            menu->Destroy(item_id);
+    }
 
     if (wxGetApp().get_mode() == comSimple && !get_app_config()->get_bool("objects_always_expert")) {
         //append_menu_item_add_text(menu, ModelVolumeType::MODEL_PART, false);
@@ -746,7 +752,7 @@ void MenuFactory::append_menu_items_add_volume(MenuType menu_type)
         wxMenu* sub_menu_enforce = new wxMenu;
         append_submenu_add_generic(sub_menu_both, sub_menu_enforce, ModelVolumeType::SUPPORT_ENFORCER);
         append_submenu(sub_menu_both, sub_menu_enforce, wxID_ANY, _L("Enforcer"), "", item_enforce.second, selected_func, m_parent);
-        append_submenu(menu, sub_menu_both, wxID_ANY, _L("Add support blocker/enforcer"), "", item_enforce.second, selected_func, m_parent);
+        append_submenu(menu, sub_menu_both, wxID_ANY, combined_support_str, "", item_enforce.second, selected_func, m_parent);
     }
     if (menu_type != mtObjectSLA) {
         // SEAM
@@ -759,7 +765,7 @@ void MenuFactory::append_menu_items_add_volume(MenuType menu_type)
         append_menu_item(sub_menu_both, wxID_ANY, _L("Seam cylinder attractor (from top to bottom)"), "",
                 [this](wxCommandEvent&) { obj_list()->load_generic_subobject(L("SmallCylinder"), ModelVolumeType::SEAM_POSITION_CENTER_Z); },
                 item_cylinder.second, nullptr, selected_func, m_parent);
-        append_submenu(menu, sub_menu_both, wxID_ANY, _L("Add seam position"), "", "add_brim", selected_func, m_parent);
+        append_submenu(menu, sub_menu_both, wxID_ANY, combined_seam_str, "", "add_brim", selected_func, m_parent);
     }
     if (menu_type != mtObjectSLA) {
         // Brim: patch or blocker
@@ -782,7 +788,7 @@ void MenuFactory::append_menu_items_add_volume(MenuType menu_type)
         wxMenu* sub_menu_blocker = new wxMenu;
         append_submenu_add_generic(sub_menu_both, sub_menu_blocker, ModelVolumeType::BRIM_NEGATIVE);
         append_submenu(sub_menu_both, sub_menu_blocker, wxID_ANY, _L("Other blockers "), "", "", selected_func, m_parent);
-        append_submenu(menu, sub_menu_both, wxID_ANY, _L("Add Brim patch/blocker"), "", "add_brim", selected_func, m_parent);
+        append_submenu(menu, sub_menu_both, wxID_ANY, combined_brim_str, "", "add_brim", selected_func, m_parent);
     }
 }
 

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -833,8 +833,8 @@ void ConfigOptionsGroup::back_to_config_value(const DynamicPrintConfig& config, 
 	}
 
     if (this->set_value(opt_key, value, enabled, false)) {
-        assert(config.option(opt_short_key));
-        on_change_OG(opt_key, config.option(opt_short_key)->is_enabled(opt_index), get_value(opt_key));
+        // assert(config.option(opt_short_key)); // extruder_count: not a real config item
+        on_change_OG(opt_key, config.has(opt_short_key) ? config.option(opt_short_key)->is_enabled(opt_index) : true, get_value(opt_key));
     }
 }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -395,8 +395,9 @@ void FreqChangedParams::sys_color_changed()
 
     for (auto btn: m_empty_buttons)
         btn->sys_color_changed();
-
-    wxGetApp().UpdateDarkUI(m_wiping_dialog_button, true);
+    if (m_wiping_dialog_button) {
+        wxGetApp().UpdateDarkUI(m_wiping_dialog_button, true);
+    }
 }
 
 FreqChangedParams::FreqChangedParams(wxWindow* parent) :

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -750,7 +750,7 @@ void Sidebar::priv::hide_rich_tip(wxButton* btn)
 // Sidebar / public
 
 Sidebar::Sidebar(Plater *parent)
-    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(42 * wxGetApp().em_unit(), -1)), p(new priv(parent))
+    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(std::max(20, get_app_config()->get_int("side_panel_width")) * wxGetApp().em_unit(), -1)), p(new priv(parent))
 {
     SetFont(wxGetApp().normal_font());
     p->scrolled = new wxScrolledWindow(this);
@@ -1003,11 +1003,18 @@ void Sidebar::init_filament_combo(PlaterPresetComboBox** combo, const int extr_i
         auto opt = wxGetApp().preset_bundle->printers.get_edited_preset().config.option<ConfigOptionStrings>("tool_name");
         assert(opt);
         std::string tool_name = opt? opt->get_at(extr_idx) : nullptr;
-        if (tool_name.size() > 10) {
-            tool_name = tool_name.substr(0,7) + std::string("... ");
+        int size_panel = get_app_config()->get_int("side_panel_width");
+        size_t max_letters  = size_t(std::max(4, size_panel/4));
+        if (tool_name.size() > max_letters) {
+            if (max_letters > 6) {
+                tool_name = tool_name.substr(0, max_letters-3) + std::string("... ");
+            } else {
+                tool_name = tool_name.substr(0, max_letters);
+            }
         }
         (*combo)->label = new wxStaticText(p->presets_panel, wxID_ANY, tool_name.empty() ? "" : ( tool_name + std::string(": ")));
         (*combo)->label->SetFont(wxGetApp().small_font());
+        (*combo)->label->SetToolTip(tool_name); //doesn't work in msw because static text doesn't get mouse event
         combo_and_btn_sizer->Add((*combo)->label, 0, wxALIGN_LEFT | wxEXPAND | wxRIGHT, 4);
     }
     combo_and_btn_sizer->Add(*combo, 1, wxEXPAND);

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -983,7 +983,13 @@ void PreferencesDialog::build()
 			L("Show layer area on the scroll bar"),
 			L("Add the layer area (the number just below the layer id) next to a widget of the layer double-scrollbar."),
 			app_config->get_bool("show_layer_area_doubleslider"));
-	}
+		
+        append_int_option(m_tabid_2_optgroups.back().back(), "side_panel_width", L("Side Panel Width"),
+                          L("The width of the right panel, where the objects , presets and slicing information are "
+                            "displayeed. It's in 'display unit'."),
+                          6, app_config->get_int("side_panel_width"));
+        m_values_need_restart.push_back("side_panel_width");
+    }
 
 	append_int_option(m_tabid_2_optgroups.back().back(), "gcodeviewer_decimals",
 		L("Decimals for gcode viewer colors"),


### PR DESCRIPTION
On systems with -ffat-lto-objects in CFLAGS/CXXFLAGS the build of TBB dependency causes diagnostics not relevant in the final build result. Due to TBB_STRICT being the default this causes build failures due to this false positive diagnostic. The easiest way around this is to disable this strict checking. After all there seems to be no point in erroring out on warnings of 3rd party dependencies anyway.