### PR TITLE
restore compatability with latest boost release

### DIFF
--- a/src/libslic3r/GCodeSender.cpp
+++ b/src/libslic3r/GCodeSender.cpp
@@ -113,7 +113,7 @@ GCodeSender::connect(std::string devname, unsigned int baud_rate)
     this->io.post(boost::bind(&GCodeSender::do_read, this));
     
     // start reading in the background thread
-    boost::thread t(boost::bind(&boost::asio::io_service::run, &this->io));
+    boost::thread t(boost::bind(&boost::asio::io_context::run, &this->io));
     this->background_thread.swap(t);
     
     // always send a M105 to check for connection because firmware might be silent on connect

--- a/src/libslic3r/GCodeSender.hpp
+++ b/src/libslic3r/GCodeSender.hpp
@@ -40,7 +40,7 @@ class GCodeSender : private boost::noncopyable {
     void reset();
     
     private:
-    asio::io_service io;
+    asio::io_context io;
     asio::serial_port serial;
     boost::thread background_thread;
     boost::asio::streambuf read_buffer, write_buffer;

--- a/src/slic3r/GUI/FirmwareDialog.cpp
+++ b/src/slic3r/GUI/FirmwareDialog.cpp
@@ -429,7 +429,7 @@ void FirmwareDialog::priv::avr109_wait_for_bootloader(Avr109Pid usb_pid, unsigne
 
 void FirmwareDialog::priv::avr109_reboot(const SerialPortInfo &port)
 {
-	asio::io_service io;
+	asio::io_context io;
 	Serial serial(io, port.port, 1200);
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 }

--- a/src/slic3r/GUI/FreeCADDialog.cpp
+++ b/src/slic3r/GUI/FreeCADDialog.cpp
@@ -64,7 +64,7 @@ namespace GUI {
     class ExecVar {
     public:
         boost::process::opstream pyin;
-        boost::asio::io_service ios;
+        boost::asio::io_context ios;
         std::future<std::string> data_out;
         std::future<std::string> data_err;
         std::unique_ptr<boost::process::child> process;

--- a/src/slic3r/GUI/RemovableDriveManager.cpp
+++ b/src/slic3r/GUI/RemovableDriveManager.cpp
@@ -35,7 +35,6 @@
 #include <pwd.h>
 #include <boost/filesystem.hpp>
 #include <boost/system/error_code.hpp>
-#include <boost/filesystem/convenience.hpp>
 #include <boost/process.hpp>
 #endif
 

--- a/src/slic3r/Utils/Bonjour.cpp
+++ b/src/slic3r/Utils/Bonjour.cpp
@@ -624,11 +624,11 @@ UdpSession::UdpSession(Bonjour::ReplyFn rfn) : replyfn(rfn)
 	buffer.resize(DnsMessage::MAX_SIZE);
 }
 
-UdpSocket::UdpSocket( Bonjour::ReplyFn replyfn, const asio::ip::address& multicast_address, const asio::ip::address& interface_address, std::shared_ptr< boost::asio::io_service > io_service)
+UdpSocket::UdpSocket( Bonjour::ReplyFn replyfn, const asio::ip::address& multicast_address, const asio::ip::address& interface_address, std::shared_ptr< boost::asio::io_context > io_context)
 	: replyfn(replyfn)
 	, multicast_address(multicast_address)
-	, socket(*io_service)
-	, io_service(io_service)
+	, socket(*io_context)
+	, io_context(io_context)
 {
 	try {
 		// open socket
@@ -658,11 +658,11 @@ UdpSocket::UdpSocket( Bonjour::ReplyFn replyfn, const asio::ip::address& multica
 }
 
 
-UdpSocket::UdpSocket( Bonjour::ReplyFn replyfn, const asio::ip::address& multicast_address, std::shared_ptr< boost::asio::io_service > io_service)
+UdpSocket::UdpSocket( Bonjour::ReplyFn replyfn, const asio::ip::address& multicast_address, std::shared_ptr< boost::asio::io_context > io_context)
 	: replyfn(replyfn)
 	, multicast_address(multicast_address)
-	, socket(*io_service)
-	, io_service(io_service)
+	, socket(*io_context)
+	, io_context(io_context)
 {
 	try {
 		// open socket
@@ -714,7 +714,7 @@ void UdpSocket::receive_handler(SharedSession session, const boost::system::erro
 	// let io_service to handle the datagram on session
 	// from boost documentation io_service::post:
 	// The io_service guarantees that the handler will only be called in a thread in which the run(), run_one(), poll() or poll_one() member functions is currently being invoked.
-	io_service->post(boost::bind(&UdpSession::handle_receive, session, error, bytes));
+	boost::asio::post(*io_context, boost::bind(&UdpSession::handle_receive, session, error, bytes));
 	// immediately accept new datagrams
 	async_receive();
 }
@@ -871,13 +871,13 @@ void Bonjour::priv::lookup_perform()
 {
 	service_dn = (boost::format("_%1%._%2%.local") % service % protocol).str();
 
-	std::shared_ptr< boost::asio::io_service > io_service(new boost::asio::io_service);
+	std::shared_ptr< boost::asio::io_context > io_context(new boost::asio::io_context);
 
 	std::vector<LookupSocket*> sockets;
 
 	// resolve intefaces - from PR#6646
 	std::vector<boost::asio::ip::address> interfaces;
-	asio::ip::udp::resolver resolver(*io_service);
+	asio::ip::udp::resolver resolver(*io_context);
 	boost::system::error_code ec;
 	// ipv4 interfaces
 	auto results = resolver.resolve(udp::v4(), asio::ip::host_name(), "", ec);
@@ -890,12 +890,12 @@ void Bonjour::priv::lookup_perform()
 		// create ipv4 socket for each interface
 		// each will send to querry to for both ipv4 and ipv6
 		for (const auto& intrfc : interfaces) 		
-			sockets.emplace_back(new LookupSocket(txt_keys, service, service_dn, protocol, replyfn, BonjourRequest::MCAST_IP4, intrfc, io_service));
+			sockets.emplace_back(new LookupSocket(txt_keys, service, service_dn, protocol, replyfn, BonjourRequest::MCAST_IP4, intrfc, io_context));
 	} else {
 		BOOST_LOG_TRIVIAL(info) << "Failed to resolve ipv4 interfaces: " << ec.message();
 	}
 	if (sockets.empty())
-		sockets.emplace_back(new LookupSocket(txt_keys, service, service_dn, protocol, replyfn, BonjourRequest::MCAST_IP4, io_service));
+		sockets.emplace_back(new LookupSocket(txt_keys, service, service_dn, protocol, replyfn, BonjourRequest::MCAST_IP4, io_context));
 	// ipv6 interfaces
 	interfaces.clear();
 	//udp::resolver::query query(host, PORT, boost::asio::ip::resolver_query_base::numeric_service);
@@ -910,9 +910,9 @@ void Bonjour::priv::lookup_perform()
 		// create ipv6 socket for each interface
 		// each will send to querry to for both ipv4 and ipv6
 		for (const auto& intrfc : interfaces)
-			sockets.emplace_back(new LookupSocket(txt_keys, service, service_dn, protocol, replyfn, BonjourRequest::MCAST_IP6, intrfc, io_service));
+			sockets.emplace_back(new LookupSocket(txt_keys, service, service_dn, protocol, replyfn, BonjourRequest::MCAST_IP6, intrfc, io_context));
 		if (interfaces.empty())
-			sockets.emplace_back(new LookupSocket(txt_keys, service, service_dn, protocol, replyfn, BonjourRequest::MCAST_IP6, io_service));
+			sockets.emplace_back(new LookupSocket(txt_keys, service, service_dn, protocol, replyfn, BonjourRequest::MCAST_IP6, io_context));
 	} else {
 		BOOST_LOG_TRIVIAL(info)<< "Failed to resolve ipv6 interfaces: " << ec.message();
 	}
@@ -923,13 +923,13 @@ void Bonjour::priv::lookup_perform()
 			socket->send();
 
 		// timer settings
-		asio::deadline_timer timer(*io_service);
+		asio::deadline_timer timer(*io_context);
 		retries--;
 		std::function<void(const error_code&)> timer_handler = [&](const error_code& error) {
 			// end 
 			if (retries == 0 || error) {
 				// is this correct ending?
-				io_service->stop();
+				io_context->stop();
 				if (completefn) {
 					completefn();
 				}
@@ -947,7 +947,7 @@ void Bonjour::priv::lookup_perform()
 		timer.expires_from_now(boost::posix_time::seconds(timeout));
 		timer.async_wait(timer_handler);
 		// start io_service, it will run until it has something to do - so in this case until stop is called in timer
-		io_service->run();
+		io_context->run();
 	}
 	catch (std::exception& e) {
 		BOOST_LOG_TRIVIAL(error) << e.what();
@@ -966,12 +966,12 @@ void Bonjour::priv::resolve_perform()
 			rpls.push_back(reply);
 	};
 
-	std::shared_ptr< boost::asio::io_service > io_service(new boost::asio::io_service);
+	std::shared_ptr< boost::asio::io_context > io_context(new boost::asio::io_context);
 	std::vector<ResolveSocket*> sockets;
 
 	// resolve interfaces - from PR#6646
 	std::vector<boost::asio::ip::address> interfaces;
-	asio::ip::udp::resolver resolver(*io_service);
+	asio::ip::udp::resolver resolver(*io_context);
 	boost::system::error_code ec;
 	// ipv4 interfaces
 	auto results = resolver.resolve(udp::v4(), asio::ip::host_name(), "", ec);
@@ -984,12 +984,12 @@ void Bonjour::priv::resolve_perform()
 		// create ipv4 socket for each interface
 		// each will send to querry to for both ipv4 and ipv6
 		for (const auto& intrfc : interfaces)
-			sockets.emplace_back(new ResolveSocket(hostname, reply_callback, BonjourRequest::MCAST_IP4, intrfc, io_service));
+			sockets.emplace_back(new ResolveSocket(hostname, reply_callback, BonjourRequest::MCAST_IP4, intrfc, io_context));
 	} else {
 		BOOST_LOG_TRIVIAL(info) << "Failed to resolve ipv4 interfaces: " << ec.message();
 	}
 	if (sockets.empty())
-		sockets.emplace_back(new ResolveSocket(hostname, reply_callback, BonjourRequest::MCAST_IP4, io_service));
+		sockets.emplace_back(new ResolveSocket(hostname, reply_callback, BonjourRequest::MCAST_IP4, io_context));
 
 	// ipv6 interfaces
 	interfaces.clear();
@@ -1003,9 +1003,9 @@ void Bonjour::priv::resolve_perform()
 		// create ipv6 socket for each interface
 		// each will send to querry to for both ipv4 and ipv6
 		for (const auto& intrfc : interfaces) 
-			sockets.emplace_back(new ResolveSocket(hostname, reply_callback, BonjourRequest::MCAST_IP6, intrfc, io_service));
+			sockets.emplace_back(new ResolveSocket(hostname, reply_callback, BonjourRequest::MCAST_IP6, intrfc, io_context));
 		if (interfaces.empty())
-			sockets.emplace_back(new ResolveSocket(hostname, reply_callback, BonjourRequest::MCAST_IP6, io_service));
+			sockets.emplace_back(new ResolveSocket(hostname, reply_callback, BonjourRequest::MCAST_IP6, io_context));
 	} else {
 		BOOST_LOG_TRIVIAL(info) << "Failed to resolve ipv6 interfaces: " << ec.message();
 	}
@@ -1016,14 +1016,14 @@ void Bonjour::priv::resolve_perform()
 			socket->send();
 
 		// timer settings
-		asio::deadline_timer timer(*io_service);
+		asio::deadline_timer timer(*io_context);
 		retries--;
 		std::function<void(const error_code&)> timer_handler = [&](const error_code& error) {
 			int replies_count = replies.size();
 			// end 
 			if (retries == 0 || error || replies_count > 0) {
 				// is this correct ending?
-				io_service->stop();
+				io_context->stop();
 				if (replies_count > 0 && resolvefn) {
 					resolvefn(replies);
 				}
@@ -1041,7 +1041,7 @@ void Bonjour::priv::resolve_perform()
 		timer.expires_from_now(boost::posix_time::seconds(timeout));
 		timer.async_wait(timer_handler);
 		// start io_service, it will run until it has something to do - so in this case until stop is called in timer
-		io_service->run();
+		io_context->run();
 	}
 	catch (std::exception& e) {
 		BOOST_LOG_TRIVIAL(error) << e.what();

--- a/src/slic3r/Utils/Bonjour.hpp
+++ b/src/slic3r/Utils/Bonjour.hpp
@@ -155,11 +155,11 @@ public:
 	UdpSocket(Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
 		, const boost::asio::ip::address& interface_address
-		, std::shared_ptr< boost::asio::io_service > io_service);
+		, std::shared_ptr< boost::asio::io_context > io_context);
 
 	UdpSocket(Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
-		, std::shared_ptr< boost::asio::io_service > io_service);
+		, std::shared_ptr< boost::asio::io_context > io_context);
 
 	void send();
 	void async_receive();
@@ -172,7 +172,7 @@ protected:
 	boost::asio::ip::address					    multicast_address;
 	boost::asio::ip::udp::socket					socket;
 	boost::asio::ip::udp::endpoint					mcast_endpoint;
-	std::shared_ptr< boost::asio::io_service >	io_service;
+	std::shared_ptr< boost::asio::io_context >	io_context;
 	std::vector<BonjourRequest>						requests;
 };
 
@@ -186,8 +186,8 @@ public:
 		, Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
 		, const boost::asio::ip::address& interface_address
-		, std::shared_ptr< boost::asio::io_service > io_service)
-		: UdpSocket(replyfn, multicast_address, interface_address, io_service)
+		, std::shared_ptr< boost::asio::io_context > io_context)
+		: UdpSocket(replyfn, multicast_address, interface_address, io_context)
 		, txt_keys(txt_keys)
 		, service(service)
 		, service_dn(service_dn)
@@ -203,8 +203,8 @@ public:
 		, std::string protocol
 		, Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
-		, std::shared_ptr< boost::asio::io_service > io_service)
-		: UdpSocket(replyfn, multicast_address, io_service)
+		, std::shared_ptr< boost::asio::io_context > io_context)
+		: UdpSocket(replyfn, multicast_address, io_context)
 		, txt_keys(txt_keys)
 		, service(service)
 		, service_dn(service_dn)
@@ -242,8 +242,8 @@ public:
 		, Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
 		, const boost::asio::ip::address& interface_address
-		, std::shared_ptr< boost::asio::io_service > io_service)
-		: UdpSocket(replyfn, multicast_address, interface_address, io_service)
+		, std::shared_ptr< boost::asio::io_context > io_context)
+		: UdpSocket(replyfn, multicast_address, interface_address, io_context)
 		, hostname(hostname)
 
 	{
@@ -254,8 +254,8 @@ public:
 	ResolveSocket(const std::string& hostname
 		, Bonjour::ReplyFn replyfn
 		, const boost::asio::ip::address& multicast_address
-		, std::shared_ptr< boost::asio::io_service > io_service)
-		: UdpSocket(replyfn, multicast_address, io_service)
+		, std::shared_ptr< boost::asio::io_context > io_context)
+		: UdpSocket(replyfn, multicast_address, io_context)
 		, hostname(hostname)
 
 	{

--- a/src/slic3r/Utils/Serial.cpp
+++ b/src/slic3r/Utils/Serial.cpp
@@ -283,12 +283,12 @@ std::vector<std::string> scan_serial_ports()
 namespace asio = boost::asio;
 using boost::system::error_code;
 
-Serial::Serial(asio::io_service& io_service) :
-	asio::serial_port(io_service)
+Serial::Serial(asio::io_context &io_context) :
+	asio::serial_port(io_context)
 {}
 
-Serial::Serial(asio::io_service& io_service, const std::string &name, unsigned baud_rate) :
-	asio::serial_port(io_service, name)
+Serial::Serial(asio::io_context &io_context, const std::string &name, unsigned baud_rate) :
+	asio::serial_port(io_context, name)
 {
 	set_baud_rate(baud_rate);
 }
@@ -391,19 +391,19 @@ void Serial::reset_line_num()
 
 bool Serial::read_line(unsigned timeout, std::string &line, error_code &ec)
 {
-	auto& io_service =
+	auto& io_context =
 #if BOOST_VERSION >= 107000
 		//FIXME this is most certainly wrong!
 		(boost::asio::io_context&)this->get_executor().context();
  #else
 		this->get_io_service();
 #endif
-	asio::deadline_timer timer(io_service);
+	asio::deadline_timer timer(io_context);
 	char c = 0;
 	bool fail = false;
 
 	while (true) {
-		io_service.reset();
+		io_context.reset();
 
 		asio::async_read(*this, boost::asio::buffer(&c, 1), [&](const error_code &read_ec, size_t size) {
 			if (ec || size == 0) {
@@ -424,7 +424,7 @@ bool Serial::read_line(unsigned timeout, std::string &line, error_code &ec)
 			});
 		}
 
-		io_service.run();
+		io_context.run();
 
 		if (fail) {
 			return false;

--- a/src/slic3r/Utils/Serial.hpp
+++ b/src/slic3r/Utils/Serial.hpp
@@ -43,8 +43,8 @@ extern std::vector<SerialPortInfo> 	scan_serial_ports_extended();
 class Serial : public boost::asio::serial_port
 {
 public:
-	Serial(boost::asio::io_service &io_service);
-	Serial(boost::asio::io_service &io_service, const std::string &name, unsigned baud_rate);
+	Serial(boost::asio::io_context &io_context);
+	Serial(boost::asio::io_context &io_context, const std::string &name, unsigned baud_rate);
 	Serial(const Serial &) = delete;
 	Serial &operator=(const Serial &) = delete;
 	~Serial();

--- a/src/slic3r/Utils/TCPConsole.cpp
+++ b/src/slic3r/Utils/TCPConsole.cpp
@@ -9,6 +9,7 @@
 #include <boost/asio/read_until.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/write.hpp>
+#include <boost/asio/connect.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/log/trivial.hpp>
@@ -161,7 +162,7 @@ bool TCPConsole::run_queue()
 
         auto endpoints = m_resolver.resolve(m_host_name, m_port_name);
 
-        m_socket.async_connect(endpoints->endpoint(),
+        boost::asio::async_connect(m_socket, endpoints,
             boost::bind(&TCPConsole::handle_connect, this, boost::placeholders::_1)
         );
 


### PR DESCRIPTION
`io_service` was deprecated and replaced with `io_context` introduced in boost `1.66` and was removed entirely  in `1.87`. Most Linux distros seem to ship `1.83`, and this is the version used by `/deps/+Boost`, but source builds on distros using a later version (e.g. Arch family using 1.87) would fail.

Additionally, `boost/filesystem/convenience.hpp` is no longer shipped as of `1.85`. Nothing from this include was used, and it has been removed.

These updates appear to introduce no build-breaking changes, as confirmed by the success of the `nightly` runners and a quick spot check from slicing a sample project using the resulting [`nightly_SuperSlicer-linux-x64-GTK3.tgz`](https://github.com/6007135/SuperSlicer/actions/runs/14161670397).

These patches were developed by the [Gentoo](https://bugs.gentoo.org/946495) and [Arch](https://aur.archlinux.org/cgit/aur.git/tree/?h=superslicer-prerelease) packagers and [have not been adopted](https://github.com/prusa3d/PrusaSlicer/issues/13799) in upstream PrusaSlicer, necessitating their use for compilation of current releases of both PrusaSlicer and SuperSlicer on distros with current boost. Rather than each distro maintaining these updates, SuperSlicer should include them for the benefit of all platforms as the later releases of boost become more prevalent.

These patches are currently shipped by Arch ([AUR](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=superslicer-prerelease)), [Gentoo](https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/prusaslicer/files), and [openSUSE](https://build.opensuse.org/projects/science/packages/PrusaSlicer/files).

This PR is a verbatim application of these patches:
[0008-boost1.85.patch](https://aur.archlinux.org/cgit/aur.git/tree/0008-boost1.85.patch?h=superslicer-prerelease)
[0012-boost1.87.patch](https://aur.archlinux.org/cgit/aur.git/tree/0012-boost1.87.patch?h=superslicer-prerelease)
[prusaslicer-2.8.1-boost-1.87.patch](https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/prusaslicer/files/prusaslicer-2.8.1-boost-1.87.patch)