### PR TITLE
use alternative OpenCASCADE

### DIFF
--- a/src/occt_wrapper/CMakeLists.txt
+++ b/src/occt_wrapper/CMakeLists.txt
@@ -19,14 +19,9 @@ include(GenerateExportHeader)
 
 generate_export_header(OCCTWrapper)
 
-find_package(OpenCASCADE 7.6.2 REQUIRED)
+find_package(OpenCASCADE REQUIRED)
 
 set(OCCT_LIBS
-    TKXDESTEP
-    TKSTEP
-    TKSTEP209
-    TKSTEPAttr
-    TKSTEPBase
     TKXCAF
     TKXSBase
     TKVCAF


### PR DESCRIPTION
Make the version of OpenCASCADE more flexible by not pulling a specific version. I found the implementation robust enough not to fail with way more recent versions, thus why not allowing those?

This also removes some dependencies to specific libraries no longer present in later versions that seem not really needed with the implementation.