### PR TITLE
proper usage of NanoSVG

### DIFF
--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -594,6 +594,7 @@ target_include_directories(libslic3r PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} PUBLIC 
 target_include_directories(libslic3r PUBLIC ${EXPAT_INCLUDE_DIRS})
 
 find_package(JPEG REQUIRED)
+find_package(NanoSVG REQUIRED)
 
 target_link_libraries(libslic3r
     libnest2d
@@ -615,6 +616,7 @@ target_link_libraries(libslic3r
     PNG::PNG
     ZLIB::ZLIB
     JPEG::JPEG
+    NanoSVG::nanosvg
     qoi
     LibBGCode::bgcode_convert
     )

--- a/src/libslic3r/Format/SL1_SVG.cpp
+++ b/src/libslic3r/Format/SL1_SVG.cpp
@@ -9,7 +9,6 @@
 #include "libslic3r/BoundingBox.hpp"
 #include "libslic3r/Format/ZipperArchiveImport.hpp"
 
-#define NANOSVG_IMPLEMENTATION
 #include "nanosvg/nanosvg.h"
 
 #include <limits>


### PR DESCRIPTION
The old code materialized the library code into the slicer binary instead of linking the library itself. This does complicate the structure and since I didn't really see the point I changed this to just link the library.