### PR TITLE
scintilla is not needed

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -203,7 +203,7 @@ then
     then
         mkdir deps/build
     fi
-    echo -e "[1/9] Configuring dependencies ...\n"
+    echo -e "[1/8] Configuring dependencies ...\n"
     BUILD_ARGS=""
     if [[ -n "$FOUND_GTK3_DEV" ]]
     then
@@ -228,32 +228,16 @@ then
     cmake .. $BUILD_ARGS
     echo -e "\n ... done\n"
 
-    echo -e "\n[2/9] Building dependencies...\n"
+    echo -e "\n[2/8] Building dependencies...\n"
     # make deps
     make -j$NCORES
-    echo -e "\n ... done\n"
-
-    # rename wxscintilla
-    echo "[3/9] Renaming wxscintilla library..."
-    pushd destdir/usr/local/lib  > /dev/null
-    if [[ -z "$FOUND_GTK3_DEV" ]]
-    then
-        cp libwxscintilla-3.2.a libwx_gtk2u_scintilla-3.2.a
-    else
-        cp libwxscintilla-3.2.a libwx_gtk3u_scintilla-3.2.a
-    fi
-    echo "> ls destdir/usr/local/lib"
-    ls -al .
-    echo "> ls ROOT/deps/build/destdir/usr/local/lib"
-    ls -al $ROOT/deps/build/destdir/usr/local/lib
-    popd > /dev/null
     popd > /dev/null
     echo -e "\n ... done\n"
 fi
 
 if [[ -n "$BUILD_CLEANDEPEND" ]]
 then
-    echo -e "[4/9] Cleaning dependencies...\n"
+    echo -e "[3/8] Cleaning dependencies...\n"
     pushd deps/build > /dev/null
     rm -fr dep_*
     popd > /dev/null
@@ -262,7 +246,7 @@ fi
 
 if [[ -n "$BUILD_SLIC3R" ]]
 then
-    echo -e "[5/9] Configuring SuperSlicer ...\n"
+    echo -e "[4/8] Configuring SuperSlicer ...\n"
     if [[ -n $BUILD_WIPE ]]
     then
        echo -n "wiping build directory ..."
@@ -317,12 +301,12 @@ then
     cmake .. -DCMAKE_PREFIX_PATH="$PWD/../deps/build/destdir/usr/local" -DSLIC3R_STATIC=1 ${BUILD_ARGS}
     echo " ... done"
     # make SuperSlicer
-    echo -e "\n[6/9] Building SuperSlicer ...\n"
+    echo -e "\n[5/8] Building SuperSlicer ...\n"
     make -j$NCORES Slic3r
     make -j$NCORES OCCTWrapper
     echo -e "\n ... done"
 
-    echo -e "\n[7/9] Generating language files ...\n"
+    echo -e "\n[6/8] Generating language files ...\n"
     #make .mo
     if [[ -n "$UPDATE_POTFILE" ]]
     then

--- a/BuildMacOS.sh
+++ b/BuildMacOS.sh
@@ -174,7 +174,7 @@ brew --prefix zstd
 export $BUILD_ARCH
 export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix zstd)/lib/
 
-echo -n "[1/9] Updating submodules..."
+echo -n "[1/8] Updating submodules..."
 {
     # update submodule profiles
     pushd resources/profiles
@@ -186,12 +186,12 @@ echo "done"
 
 if [[ -n "$VERSION_DATE" ]]
 then
-	echo -n "[2/9] Changing date in version ... "
+	echo -n "[2/8] Changing date in version ... "
     # change date in version
     sed "s/+UNKNOWN/-$(date '+%F')/" version.inc > version.date.inc
 	echo "done"
 else
-	echo -n "[2/9] Changing date in version: remove UNKNOWN ... "
+	echo -n "[2/8] Changing date in version: remove UNKNOWN ... "
     sed "s/+UNKNOWN//" version.inc > version.date.inc
 	echo "done"
 fi
@@ -209,7 +209,7 @@ then
     then
         mkdir deps/build
     fi
-    echo -e " \n[3/9] Configuring dependencies ... \n"
+    echo -e " \n[3/8] Configuring dependencies ... \n"
     BUILD_ARGS=""
     if [[ -n "$BUILD_ARCH" ]]
     then
@@ -231,7 +231,7 @@ then
         exit 1 # terminate and indicate error
     fi
 
-    echo -e "[4/9] Building dependencies ...\n"
+    echo -e "[4/8] Building dependencies ...\n"
 
     # make deps
     make -j$NCORES
@@ -243,20 +243,12 @@ then
         exit 1 # terminate and indicate error
     fi
 
-    echo -e "[5/9] Renaming wxscintilla library ...\n"
-
-    # rename wxscintilla
-    pushd destdir/usr/local/lib > /dev/null
-    cp libwxscintilla-3.2.a libwx_osx_cocoau_scintilla-3.2.a
-
     popd > /dev/null
-    popd > /dev/null
-    echo -e "\n ... done\n"
 fi
 
 if [[ -n "$BUILD_CLEANDEPEND" ]]
 then
-    echo -e "[6/9] Cleaning dependencies...\n"
+    echo -e "[5/8] Cleaning dependencies...\n"
     pushd deps/build
     pwd
     rm -fr dep_*
@@ -266,7 +258,7 @@ fi
 
 if [[ -n "$BUILD_SLIC3R" ]]
 then
-    echo -e "[5/9] Configuring Slicer ...\n"
+    echo -e "[4/8] Configuring Slicer ...\n"
 
     if [[ -n $BUILD_WIPE ]]
     then
@@ -316,7 +308,7 @@ then
     # make Slic3r
     if [[ -z "$BUILD_XCODE" ]]
     then
-        echo -e "\n[6/9] Building Slicer ...\n"
+        echo -e "\n[5/8] Building Slicer ...\n"
         make -j$NCORES Slic3r
         if [ $? -eq 0 ]
         then
@@ -327,7 +319,7 @@ then
         fi
     fi
 
-    echo -e "\n[7/9] Generating language files ...\n"
+    echo -e "\n[6/8] Generating language files ...\n"
     #make .mo
     if [[ -n "$UPDATE_POTFILE" ]]
     then

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ if (SLIC3R_GUI)
     if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         set (wxWidgets_CONFIG_OPTIONS "--toolkit=gtk${SLIC3R_GTK}")
             endif ()
-    find_package(wxWidgets 3.2 MODULE REQUIRED COMPONENTS base core adv html gl stc scintilla)
+    find_package(wxWidgets 3.2 MODULE REQUIRED COMPONENTS base core adv html gl stc)
 
     include(${wxWidgets_USE_FILE})
 

--- a/src/platform/osx/BuildMacOSImage.sh.in
+++ b/src/platform/osx/BuildMacOSImage.sh.in
@@ -37,7 +37,7 @@ while getopts ":ixavh" opt; do
   esac
 done
 
-    echo -e "\n[8/9] Generating MacOS app..."
+    echo -e "\n[7/8] Generating MacOS app..."
 #    {
         # update Info.plist
         pushd src
@@ -111,7 +111,7 @@ DMG_NAME=@SLIC3R_APP_KEY@${VERSION_NUMBER}-$OS_NAME.dmg
 
 if [[ -n "$BUILD_IMAGE" ]]
 then
-echo -e "\n[9/9] Creating .tgz and DMG Image for distribution..."
+echo -e "\n[8/8] Creating .tgz and DMG Image for distribution..."
   {
 
     tar -czvf @SLIC3R_APP_KEY@${VERSION_NUMBER}-$OS_NAME.tgz pack/@SLIC3R_APP_KEY@

--- a/src/platform/unix/BuildLinuxImage.sh.in
+++ b/src/platform/unix/BuildLinuxImage.sh.in
@@ -49,7 +49,7 @@ done
 
 if [[ -n "$BUILD_APP" ]]
 then
-    echo -e "\n[8/9] Generating Linux app ..."
+    echo -e "\n[7/8] Generating Linux app ..."
     # create directory and copy into it
     if [ -d "package" ]
     then
@@ -88,7 +88,7 @@ fi
 
 if [[ -n "$BUILD_IMAGE" ]]
 then
-    echo -e "\n[9/9] Creating .tgz and Appimage for distribution ...\n"
+    echo -e "\n[8/8] Creating .tgz and Appimage for distribution ...\n"
 
     pushd package > /dev/null
     if [[ -z "$FORCE_GTK2" ]]


### PR DESCRIPTION
Why are we jumping through hoops for something we don't need?

There was special handling for the scintilla integration in wxWidgets despite that fact that we actually don't even need it in the code. This removes this useless dependency and the corresponding special handling of the library.

It also removes the weird counting in the build scripts that never counted to the maximal number that was listed there anyway.