### PR TITLE
Port to FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ if (APPLE)
     endif ()
 endif ()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     find_package(PkgConfig REQUIRED)
 
     if (CMAKE_VERSION VERSION_LESS "3.1")
@@ -485,7 +485,9 @@ include_directories(BEFORE SYSTEM ${EIGEN3_INCLUDE_DIR})
 # no matter what.
 find_package(EXPAT REQUIRED)
 
-add_library(libexpat INTERFACE)
+if (NOT TARGET libexpat)
+    add_library(libexpat INTERFACE)
+endif ()
 
 if (TARGET EXPAT::EXPAT )
     target_link_libraries(libexpat INTERFACE EXPAT::EXPAT)

--- a/src/avrdude/libavrdude.h
+++ b/src/avrdude/libavrdude.h
@@ -951,7 +951,7 @@ int read_config_builtin();
 #if defined(WIN32NATIVE)
 #  include <malloc.h>
 #else
-#  include <alloca.h>
+#  include <stdlib.h>
 #endif
 
 

--- a/src/hidapi/CMakeLists.txt
+++ b/src/hidapi/CMakeLists.txt
@@ -3,6 +3,8 @@ if (WIN32)
     set(HIDAPI_IMPL win/hid.c)
 elseif (APPLE)
     set(HIDAPI_IMPL mac/hid.c)
+elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(HIDAPI_IMPL libusb/hid.c)
 else ()
     # Assume Linux or Unix other than Mac OS
     set(HIDAPI_IMPL linux/hid.c)
@@ -12,8 +14,11 @@ include_directories(include)
 
 add_library(hidapi STATIC ${HIDAPI_IMPL})
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
 	# Don't link the udev library, as there are two versions out there (libudev.so.0, libudev.so.1), so they are linked explicitely.
 #	target_link_libraries(hidapi udev)
 	target_link_libraries(hidapi dl)
+endif()
+if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    target_link_libraries(hidapi usb iconv)
 endif()

--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -205,7 +205,7 @@ typedef std::vector<std::string>    t_config_option_keys;
 // idx is -1 if it's not a vector, or if the whole vector is used.
 struct OptionKeyIdx
 {
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
     // apple 'set<X> t2 = t1' needs the assignment operator, that needs to have no const data
     t_config_option_key key;
     int32_t idx;

--- a/src/libslic3r/Platform.cpp
+++ b/src/libslic3r/Platform.cpp
@@ -90,6 +90,10 @@ void detect_platform()
     BOOST_LOG_TRIVIAL(info) << "Platform: OpenBSD";
 	s_platform 		  = Platform::BSDUnix;
 	s_platform_flavor = PlatformFlavor::OpenBSD;
+#elif defined(__FreeBSD__)
+    BOOST_LOG_TRIVIAL(info) << "Platform: FreeBSD";
+       s_platform                = Platform::BSDUnix;
+       s_platform_flavor = PlatformFlavor::FreeBSD;
 #else
 	// This should not happen.
     BOOST_LOG_TRIVIAL(info) << "Platform: Unknown";
@@ -137,6 +141,7 @@ std::string platform_flavor_to_string(PlatformFlavor pf)
         case PlatformFlavor::LinuxOnChromium : return "LinuxOnChromium";
         case PlatformFlavor::WSL             : return "WSL";
         case PlatformFlavor::WSL2            : return "WSL2";
+        case PlatformFlavor::FreeBSD         : return "FreeBSD";
         case PlatformFlavor::OpenBSD         : return "OpenBSD";
         case PlatformFlavor::GenericOSX      : return "GenericOSX";
         case PlatformFlavor::OSXOnX86        : return "OSXOnX86";

--- a/src/libslic3r/Platform.hpp
+++ b/src/libslic3r/Platform.hpp
@@ -29,6 +29,7 @@ enum class PlatformFlavor
     WSL,             // Microsoft's Windows on Linux (Linux kernel simulated on NTFS kernel)
     WSL2,            // Microsoft's Windows on Linux, version 2 (virtual machine)
     OpenBSD,         // For Platform::BSDUnix
+    FreeBSD,         // For Platform::BSDUnix
     GenericOSX,      // For Platform::OSX
     OSXOnX86,        // For Apple's on Intel X86 CPU
     OSXOnArm,        // For Apple's on Arm CPU

--- a/src/occt_wrapper/CMakeLists.txt
+++ b/src/occt_wrapper/CMakeLists.txt
@@ -92,6 +92,7 @@ slic3r_remap_configs("${OCCT_LIBS}" RelWithDebInfo Release)
 
 target_include_directories(OCCTWrapper PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(OCCTWrapper PUBLIC ${OpenCASCADE_INCLUDE_DIR})
+target_link_directories(OCCTWrapper PUBLIC ${OpenCASCADE_LIBRARY_DIR})
 target_link_libraries(OCCTWrapper ${OCCT_LIBS})
 
 include(GNUInstallDirs)

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -417,7 +417,7 @@ target_link_libraries(libslic3r_gui libslic3r avrdude libcereal imgui GLEW::GLEW
 
 if (MSVC)
     target_link_libraries(libslic3r_gui Setupapi.lib)
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     target_link_libraries(libslic3r_gui ${DBUS_LIBRARIES}) 
 elseif (APPLE)
     target_link_libraries(libslic3r_gui ${DISKARBITRATION_LIBRARY} ${COREWLAN_LIBRARY})

--- a/src/slic3r/GUI/ConfigWizard.cpp
+++ b/src/slic3r/GUI/ConfigWizard.cpp
@@ -68,11 +68,11 @@
 #include "slic3r/GUI/I18N.hpp"
 #include "slic3r/Config/Version.hpp"
 
-#if defined(__linux__) && defined(__WXGTK3__)
+#if (defined(__linux__) || defined(__FreeBSD__)) && defined(__WXGTK3__)
 #define wxLinux_gtk3 true
 #else
 #define wxLinux_gtk3 false
-#endif //defined(__linux__) && defined(__WXGTK3__)
+#endif //(defined(__linux__) || defined(__FreeBSD__)) && defined(__WXGTK3__)
 
 namespace Slic3r {
 namespace GUI {
@@ -610,7 +610,7 @@ void PageWelcome::set_run_reason(ConfigWizard::RunReason run_reason)
     const bool data_empty = run_reason == ConfigWizard::RR_DATA_EMPTY;
     welcome_text->Show(data_empty);
     cbox_reset->Show(!data_empty);
-#if defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)
+#if (defined(__linux__) || defined(__FreeBSD__)) && defined(SLIC3R_DESKTOP_INTEGRATION)
     if (!DesktopIntegrationDialog::is_integrated())
         cbox_integrate->Show(true);
     else
@@ -1537,9 +1537,9 @@ PageDownloader::PageDownloader(ConfigWizard* parent)
         ));
     }
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
     append_text(wxString::Format(_L(
-        "On Linux systems the process of registration also creates desktop integration files for this version of application."
+        "On Linux and FreeBSD systems the process of registration also creates desktop integration files for this version of application."
     )));
 #endif
 
@@ -3156,7 +3156,7 @@ bool ConfigWizard::priv::apply_config(AppConfig *app_config, PresetBundle *prese
         if ((check_unsaved_preset_changes = install_bundles.size() > 0))
             header = _L_PLURAL("A new vendor was installed and one of its printers will be activated", "New vendors were installed and one of theirs printers will be activated", install_bundles.size());
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
     // Desktop integration on Linux
     BOOST_LOG_TRIVIAL(debug) << "ConfigWizard::priv::apply_config integrate_desktop" << page_welcome->integrate_desktop()  << " perform_registration_linux " << page_downloader->m_downloader->get_perform_registration_linux();
     if (page_welcome->integrate_desktop())

--- a/src/slic3r/GUI/ConfigWizard.hpp
+++ b/src/slic3r/GUI/ConfigWizard.hpp
@@ -32,7 +32,7 @@ namespace DownloaderUtils {
         wxWindow*   m_parent{ nullptr };
         wxTextCtrl* m_input_path{ nullptr };
         bool        downloader_checked{ false };
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
         bool        perform_registration_linux{ false };
 #endif // __linux__
 
@@ -51,7 +51,7 @@ namespace DownloaderUtils {
 
         bool on_finish();
         bool perform_register(const std::string& path_override = {});
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
         bool get_perform_registration_linux() { return perform_registration_linux; }
 #endif // __linux__
     };

--- a/src/slic3r/GUI/DesktopIntegrationDialog.cpp
+++ b/src/slic3r/GUI/DesktopIntegrationDialog.cpp
@@ -3,7 +3,7 @@
 ///|/
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 #include "DesktopIntegrationDialog.hpp"
 #include "GUI_App.hpp"
 #include "GUI.hpp"

--- a/src/slic3r/GUI/DesktopIntegrationDialog.hpp
+++ b/src/slic3r/GUI/DesktopIntegrationDialog.hpp
@@ -2,7 +2,7 @@
 ///|/
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 #ifndef slic3r_DesktopIntegrationDialog_hpp_
 #define slic3r_DesktopIntegrationDialog_hpp_
 

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -459,7 +459,7 @@ void desktop_open_folder(const boost::filesystem::path& path)
 #endif
 }
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 namespace {
 wxExecuteEnv get_appimage_exec_env()
 {

--- a/src/slic3r/GUI/GUI.hpp
+++ b/src/slic3r/GUI/GUI.hpp
@@ -85,7 +85,7 @@ extern void desktop_open_datadir_folder();
 // Ask the destop to open the directory specified by path using the default file explorer.
 void desktop_open_folder(const boost::filesystem::path& path);
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 // Calling wxExecute on Linux with proper handling of AppImage's env vars.
 // argv example: { "xdg-open", path.c_str(), nullptr }
 void desktop_execute(const char* argv[]);

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -494,7 +494,7 @@ private:
 };
 
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 bool static check_old_linux_datadir(const wxString& app_name) {
     // If we are on Linux and the datadir does not exist yet, look into the old
     // location where the datadir was before version 2.3. If we find it there,
@@ -1066,7 +1066,7 @@ void GUI_App::init_app_config()
         if (boost::filesystem::exists(boost::filesystem::path{ resources_dir() } / ".." / "configuration")) {
             set_data_dir((boost::filesystem::path{ resources_dir() } / ".." / "configuration").string());
         } else {
-#ifndef __linux__
+#if !(defined(__linux__) || defined(__FreeBSD__))
             set_data_dir(wxStandardPaths::Get().GetUserDataDir().ToUTF8().data());
         }
 #else
@@ -1289,7 +1289,7 @@ bool GUI_App::on_init_inner()
     wxCHECK_MSG(wxDirExists(resources_dir), false,
         wxString::Format("Resources path does not exist or is not a directory: %s", resources_dir));
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
     if (! check_old_linux_datadir(GetAppName())) {
         std::cerr << "Quitting, user chose to move their data to new location." << std::endl;
         return false;
@@ -1611,7 +1611,7 @@ bool GUI_App::on_init_inner()
         // and wxEVT_SET_FOCUS before GUI_App::post_init is called) wasn't called before GUI_App::post_init and OpenGL wasn't initialized.
         // Since issue #9774 Where same problem occured on MacOS Ventura, we decided to have this check on MacOS as well.
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
         if (!m_post_initialized && m_opengl_initialized) {
 #else
         if (!m_post_initialized) {
@@ -2608,7 +2608,7 @@ bool GUI_App::switch_language()
     }
 }
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 static const wxLanguageInfo* linux_get_existing_locale_language(const wxLanguageInfo* language,
                                                                 const wxLanguageInfo* system_language)
 {
@@ -2818,7 +2818,7 @@ bool GUI_App::load_language(wxString language, bool initial)
 				m_language_info_best = wxLocale::FindLanguageInfo(best_language);
 	        	BOOST_LOG_TRIVIAL(trace) << boost::format("Best translation language detected (may be different from user locales): %1%") % m_language_info_best->CanonicalName.ToUTF8().data();
 			}
-            #ifdef __linux__
+            #if defined(__linux__) || defined(__FreeBSD__)
             wxString lc_all;
             if (wxGetEnv("LC_ALL", &lc_all) && ! lc_all.IsEmpty()) {
                 // Best language returned by wxWidgets on Linux apparently does not respect LC_ALL.
@@ -2871,7 +2871,7 @@ bool GUI_App::load_language(wxString language, bool initial)
     } else if (m_language_info_system != nullptr && language_info->CanonicalName.BeforeFirst('_') == m_language_info_system->CanonicalName.BeforeFirst('_'))
         language_info = m_language_info_system;
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
     // If we can't find this locale , try to use different one for the language
     // instead of just reporting that it is impossible to switch.
     if (! wxLocale::IsAvailable(language_info->Language)) {
@@ -3010,7 +3010,7 @@ void GUI_App::add_config_menu(wxMenuBar *menu)
         local_menu->Append(config_id_base + ConfigMenuTakeSnapshot, _L("Take Configuration &Snapshot"), _L("Capture a configuration snapshot"));
         local_menu->Append(config_id_base + ConfigMenuUpdateConf, _L("Check for Configuration Updates"), _L("Check for configuration updates"));
         local_menu->Append(config_id_base + ConfigMenuUpdateApp, _L("Check for Application Updates"), _L("Check for new version of application"));
-#if defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION) 
+#if (defined(__linux__) || defined(__FreeBSD__)) && defined(SLIC3R_DESKTOP_INTEGRATION)
         //if (DesktopIntegrationDialog::integration_possible())
         local_menu->Append(config_id_base + ConfigMenuDesktopIntegration, _L("Desktop Integration"), _L("Desktop Integration"));    
 #endif //(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)        
@@ -3067,7 +3067,7 @@ void GUI_App::add_config_menu(wxMenuBar *menu)
         case ConfigMenuUpdateApp:
             app_version_check(true);
             break;
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
         case ConfigMenuDesktopIntegration:
             show_desktop_integration_dialog();
             break;
@@ -3732,7 +3732,7 @@ bool GUI_App::run_wizard(ConfigWizard::RunReason reason, ConfigWizard::StartPage
 
 void GUI_App::show_desktop_integration_dialog()
 {
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
     //wxCHECK_MSG(mainframe != nullptr, false, "Internal error: Main frame not created / null");
     DesktopIntegrationDialog dialog(mainframe);
     dialog.ShowModal();
@@ -3752,7 +3752,7 @@ void GUI_App::show_downloader_registration_dialog()
     if (msg.ShowModal() == wxID_YES) {
         auto downloader_worker = new DownloaderUtils::Worker(nullptr);
         downloader_worker->perform_register(app_config->get("url_downloader_dest"));
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
         if (downloader_worker->get_perform_registration_linux())
             DesktopIntegrationDialog::perform_downloader_desktop_integration();
 #endif // __linux__

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1633,7 +1633,7 @@ void MenuFactory::sys_color_changed(wxMenuBar* menubar)
     for (size_t id = 0; id < menubar->GetMenuCount(); id++) {
         wxMenu* menu = menubar->GetMenu(id);
         sys_color_changed_menu(menu);
-#ifndef __linux__
+#if !(defined(__linux__) || defined(__FreeBSD__))
         menu->SetupBitmaps();
 #ifdef _WIN32 
         // but under MSW we have to update item's bachground color

--- a/src/slic3r/GUI/InstanceCheck.cpp
+++ b/src/slic3r/GUI/InstanceCheck.cpp
@@ -27,7 +27,7 @@
 #include <strsafe.h>
 #endif //WIN32
 
-#if __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 #include <mutex>
 #include <dbus/dbus.h> /* Pull in all of D-Bus headers. */
 #endif //__linux__
@@ -227,7 +227,7 @@ namespace instance_check_internal
 		return false;
 	}
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
 
 	static bool  send_message(const std::string &message_text, const std::string &version)
 	{
@@ -315,7 +315,7 @@ bool instance_check(int argc, char** argv, bool app_config_single_instance)
 	hashed_path = std::hash<std::string>{}(boost::filesystem::system_complete(argv[0]).string());
 #else
 	boost::system::error_code ec;
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 	// If executed by an AppImage, start the AppImage, not the main process.
 	// see https://docs.appimage.org/packaging-guide/environment-variables.html#id2
 	const char *appimage_env = std::getenv("APPIMAGE");

--- a/src/slic3r/GUI/InstanceCheck.hpp
+++ b/src/slic3r/GUI/InstanceCheck.hpp
@@ -15,7 +15,7 @@
 
 #include <boost/filesystem.hpp>
 
-#if __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 #include <boost/thread.hpp>
 #include <mutex>
 #include <condition_variable>
@@ -42,7 +42,7 @@ namespace GUI {
 
 class MainFrame;
 
-#if __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
     #define BACKGROUND_MESSAGE_LISTENER
 #endif // __linux__
 

--- a/src/slic3r/GUI/OpenGLManager.cpp
+++ b/src/slic3r/GUI/OpenGLManager.cpp
@@ -344,10 +344,12 @@ bool OpenGLManager::init_gl()
         glewExperimental = true;
 #endif // ENABLE_GL_CORE_PROFILE || ENABLE_OPENGL_ES
         GLenum err = glewInit();
+#ifndef __FreeBSD__
         if (err != GLEW_OK) {
             BOOST_LOG_TRIVIAL(error) << "Unable to init glew library: " << glewGetErrorString(err);
             return false;
         }
+#endif
 
 #if ENABLE_GL_CORE_PROFILE
         do {

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -37,7 +37,7 @@
 #ifdef WIN32
 #include <wx/msw/registry.h>
 #endif // WIN32
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 #include "DesktopIntegrationDialog.hpp"
 #endif //__linux__
 
@@ -1281,7 +1281,7 @@ void PreferencesDialog::accept(wxEvent&)
 			this->m_downloader->allow(it->second == "1");
 		if (!this->m_downloader->on_finish())
 			return;
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 		if( this->m_downloader->get_perform_registration_linux()) 
 			DesktopIntegrationDialog::perform_downloader_desktop_integration();
 #endif // __linux__

--- a/src/slic3r/Utils/WifiScanner.cpp
+++ b/src/slic3r/Utils/WifiScanner.cpp
@@ -17,7 +17,7 @@
 #include "WifiScannerMac.h"
 #endif 
 
-#if __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 #include <dbus/dbus.h> /* Pull in all of D-Bus headers. */
 #endif //__linux__
 

--- a/src/test-utils/CMakeLists.txt
+++ b/src/test-utils/CMakeLists.txt
@@ -3,8 +3,12 @@ project(test-utils)
 # convert stl to c++ code to inclusion in test
 add_executable(stl_to_cpp stl_to_cpp.cpp)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    target_link_libraries(stl_to_cpp libslic3r xcb)
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    find_package(X11 REQUIRED)
+endif()
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    target_link_libraries(stl_to_cpp libslic3r X11::xcb)
 else ()
     target_link_libraries(stl_to_cpp libslic3r)
 endif ()
@@ -18,8 +22,8 @@ endif()
 # test your vendor config, helping to convert from prusaslicer.
 add_executable(convert_config convert_config.cpp)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    target_link_libraries(convert_config libslic3r xcb)
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    target_link_libraries(convert_config libslic3r X11::xcb)
 else ()
     target_link_libraries(convert_config libslic3r)
 endif ()

--- a/src/test-utils/ClipboardXX/include/clipboardxx.hpp
+++ b/src/test-utils/ClipboardXX/include/clipboardxx.hpp
@@ -4,7 +4,7 @@
 #if defined(_WIN32) || defined(WIN32)
     #define WINDOWS
     #include "detail/windows.hpp"
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
     #define LINUX
     #include "detail/linux.hpp"
 #else


### PR DESCRIPTION
A new from-scratch port of SuperSlicer to FreeBSD.

For the most part, this is just making FreeBSD use the same code as Linux, but there's a couple other changes:
1. Only add libexpect target if it's not already there... "something else" is already adding it, which causes cmake to fail, so I just made the add_library() conditional on the target.
2. Change include alloca.h to stdlib.h in avrdude... stdlib.h has been standard for a long time for this.
3. Ignore glewInit() result on FreeBSD.