### PR TITLE
Fix segfault and thread safety issues in GCode generation

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1020,10 +1020,13 @@ namespace DoExport {
                 std::set<double> mm3_per_mm;
                 for (auto object : print.objects()) {
                     for (size_t region_id = 0; region_id < object->num_printing_regions(); ++region_id) {
-                        const PrintRegion &region = object->printing_region(region_id);
+                        auto region_ptr = object->printing_region_ptr(region_id);
+                        if (!region_ptr) continue;
+                        const PrintRegion &region = *region_ptr;
                         for (auto layer : object->layers()) {
                             const LayerRegion *layerm = layer->regions()[region_id];
                             const LayerTools *tools_for_layer = tool_ordering.tools_for_layer(layer->print_z);
+                            if (!tools_for_layer) continue;
                             if (tools_for_layer->perimeter_extruder(layerm->region().config()) == extruder_id &&
                                 compute_min_mm3_per_mm.is_compatible(
                                     {ExtrusionRole::Perimeter, ExtrusionRole::ExternalPerimeter,
@@ -1044,6 +1047,7 @@ namespace DoExport {
                     }
                     for (auto layer : object->support_layers()) {
                         const LayerTools *layer_tools = tool_ordering.tools_for_layer(layer->print_z);
+                        if (!layer_tools) continue;
                         // Soluble?
                         bool soluble = print.config().filament_soluble.get_at(extruder_id);
                         uint16_t support_extruder = object->config().support_material_extruder;

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -45,6 +45,7 @@
 #include <atomic>
 #include <ctime>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <set>
 #include <tcbspan/span.hpp>
@@ -284,7 +285,7 @@ public:
         SupportSpotsGenerator::PartialObjects partial_objects;
     };
 
-    std::vector<std::unique_ptr<PrintRegion>>   all_regions;
+    std::vector<std::shared_ptr<PrintRegion>>   all_regions;
     std::vector<LayerRangeRegions>              layer_ranges;
     // Transformation of this ModelObject into one of the associated PrintObjects (all PrintObjects derived from a single modelObject differ by a Z rotation only).
     // This transformation is used to calculate VolumeExtents.
@@ -382,8 +383,9 @@ public:
     const SlicingParameters&                    slicing_parameters() const { return *m_slicing_params; }
     static std::shared_ptr<SlicingParameters>   slicing_parameters(const DynamicPrintConfig &full_config, const ModelObject &model_object, float object_max_z);
 
-    size_t                      num_printing_regions() const throw() { assert(m_shared_regions); return m_shared_regions->all_regions.size(); }
-    const PrintRegion&          printing_region(size_t idx) const throw() { assert(m_shared_regions); return *m_shared_regions->all_regions[idx].get(); }
+    size_t                                      num_printing_regions() const throw() { assert(m_shared_regions); return m_shared_regions->all_regions.size(); }
+    const PrintRegion&                          printing_region(size_t idx) const throw() { assert(m_shared_regions); return *m_shared_regions->all_regions[idx].get(); }
+    std::shared_ptr<const PrintRegion>          printing_region_ptr(size_t idx) const throw() { assert(m_shared_regions); return m_shared_regions->all_regions[idx]; }
     //FIXME returing all possible regions before slicing, thus some of the regions may not be slicing at the end.
     std::vector<std::reference_wrapper<const PrintRegion>> all_regions() const;
     const PrintObjectRegions*   shared_regions() const throw() { return m_shared_regions; }

--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -663,7 +663,7 @@ bool verify_update_print_object_regions(
     // Sort by ModelVolume ID.
     model_volumes_sort_by_id(model_volumes);
 
-    for (std::unique_ptr<PrintRegion> &region : print_object_regions.all_regions)
+    for (std::shared_ptr<PrintRegion> &region : print_object_regions.all_regions)
         print_region_ref_reset(*region);
 
     // Verify and / or update PrintRegions produced by ModelVolumes, layer range modifiers, modifier volumes.
@@ -758,7 +758,7 @@ bool verify_update_print_object_regions(
     {
         std::vector<const PrintRegion*> regions;
         regions.reserve(print_object_regions.all_regions.size());
-        for (std::unique_ptr<PrintRegion> &region : print_object_regions.all_regions) {
+        for (std::shared_ptr<PrintRegion> &region : print_object_regions.all_regions) {
             assert(print_region_ref_cnt(*region) > 0);
             regions.emplace_back(&(*region.get()));
         }
@@ -898,7 +898,7 @@ static PrintObjectRegions* generate_print_object_regions(
         if (it != region_set.end() && (*it)->config_hash() == hash && (*it)->config() == config)
             return *it;
         // Insert into a sorted array, it has O(n) complexity, but the calling algorithm has an O(n^2*log(n)) complexity anyways.
-        all_regions.emplace_back(std::make_unique<PrintRegion>(std::move(config), hash, int(all_regions.size())));
+        all_regions.emplace_back(std::make_shared<PrintRegion>(std::move(config), hash, int(all_regions.size())));
         PrintRegion *region = all_regions.back().get();
         region_set.emplace(it, region);
         return region;
@@ -1473,7 +1473,7 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
         for (PrintObject *print_object : m_objects)
             if (print_object_regions != print_object->m_shared_regions) {
                 print_object_regions = print_object->m_shared_regions;
-                for (std::unique_ptr<Slic3r::PrintRegion> &print_region : print_object_regions->all_regions)
+                for (std::shared_ptr<Slic3r::PrintRegion> &print_region : print_object_regions->all_regions)
                     if (auto it = region_set.find(print_region.get()); it == region_set.end()) {
                         int print_region_id = int(m_print_regions.size());
                         m_print_regions.emplace_back(print_region.get());

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -172,7 +172,7 @@ std::vector<std::reference_wrapper<const PrintRegion>> PrintObject::all_regions(
 {
     std::vector<std::reference_wrapper<const PrintRegion>> out;
     out.reserve(m_shared_regions->all_regions.size());
-    for (const std::unique_ptr<Slic3r::PrintRegion> &region : m_shared_regions->all_regions) {
+    for (const std::shared_ptr<Slic3r::PrintRegion> &region : m_shared_regions->all_regions) {
         out.emplace_back(*region.get());
     }
     return out;

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -560,7 +560,7 @@ static std::vector<std::vector<ExPolygons>> slices_to_regions(
     for(auto &slices : slices_by_region) for(auto &expolys : slices) assert_valid(expolys);
 
     // filament shrink
-    for (const std::unique_ptr<PrintRegion>& pr : print_object_regions.all_regions) {
+    for (const std::shared_ptr<PrintRegion>& pr : print_object_regions.all_regions) {
         if (pr.get()) {
             std::vector<ExPolygons>& region_polys = slices_by_region[pr->print_object_region_id()];
             const size_t extruder_id = pr->extruder(FlowRole::frPerimeter, print_object) - 1;
@@ -1625,7 +1625,7 @@ void PrintObject::slice_volumes()
     for (Layer* layer : m_layers) {
         layer->m_regions.clear();
         layer->m_regions.reserve(m_shared_regions->all_regions.size());
-        for (const std::unique_ptr<PrintRegion> &pr : m_shared_regions->all_regions)
+        for (const std::shared_ptr<PrintRegion> &pr : m_shared_regions->all_regions)
             layer->m_regions.emplace_back(new LayerRegion(layer, pr.get()));
     }
 


### PR DESCRIPTION
Fixes #4701 segmentation fault at GCode/ToolOrdering.cpp:50

Fix a crash in background slicing thread (`slic3r_BgSlcPcs`) where null pointers were being dereferenced during volumetric limit calculations.

- Replace unique_ptr with shared_ptr for PrintRegion to prevent use-after-free in multi-threaded slicing context
- Add null pointer checks for tools_for_layer in autospeed calculation to prevent segfault when layer tools are unavailable
- Add null check for layer_tools in support layers processing
- Add null check for region_ptr before dereferencing