### PR TITLE
Fix TreeModelVolumes division by zero in tree support generation

### DIFF
--- a/src/libslic3r/Support/TreeModelVolumes.cpp
+++ b/src/libslic3r/Support/TreeModelVolumes.cpp
@@ -664,6 +664,9 @@ void TreeModelVolumes::calculateAvoidance(const std::vector<RadiusLayerPair> &ke
             // Limiting the offset step so that unioning the shrunk latest_avoidance with the current layer collisions
             // will not create gaps in the resulting avoidance region letting a tree support branch tunneling through an object wall.
             float move_step      = 1.9 * std::max(task.radius, m_current_min_xy_dist);
+            // Threshold must be >= 0.5 to prevent division by zero when move_step is cast to int in round_up_divide
+            // Note: Early return skips cache insertion (line 709), causing getAvoidance() to recalculate on every access
+            if (move_step < 0.5f) return;
             int   move_steps     = round_up_divide<int>(max_move, move_step);
             assert(move_steps > 0);
             float last_move_step = max_move - (move_steps - 1) * move_step;


### PR DESCRIPTION
[CWE-369: Division by Zero](https://cwe.mitre.org/data/definitions/369.html)

Address a division by zero crash in tree support generation when `xy_distance` is zero, ported from OrcaSlicer. Add a validation check before the division operation in `TreeModelVolumes::calculateAvoidance()`.

The original OrcaSlicer commit adds early return check `if (move_step < EPSILON)` before division operation to prevent crash when both `task.radius` and `m_current_min_xy_dist` are zero

But! EPSILON (1e-4) is too small - values < 0.5 truncate to 0 in `round_up_divide<int>()`

Also note, that early return skips cache insertion, causing a tiny performance degradation.

This PR
- Changed threshold from `EPSILON` to `0.5f` because `round_up_divide<int>()` casts `move_step` to int before division. Thus any value < 0.5 becomes 0 after cast, causing division by zero. And 0.5f ensures at least 1 after int conversion.

The early return is intentional - degenerate geometry (zero radius/distance) should not populate the cache.

OrcaSlicer PR: https://github.com/SoftFever/OrcaSlicer/pull/11189