### PR TITLE
Fix division by zero in CoolingBuffer

### DIFF
--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -189,7 +189,8 @@ struct PerExtruderAdjustments
                 line.slowdown = true;
                 line.time     = line.time_max;
                 assert(line.time > 0);
-                line.feedrate = line.length / line.time;
+                if (line.time > 0.f)
+                    line.feedrate = line.length / line.time;
             }
             time_total += line.time;
         }
@@ -205,7 +206,8 @@ struct PerExtruderAdjustments
                 line.slowdown = true;
                 line.time     = std::min(line.time_max, line.time * factor);
                 assert(line.time > 0);
-                line.feedrate = line.length / line.time;
+                if (line.time > 0.f)
+                    line.feedrate = line.length / line.time;
             }
             time_total += line.time;
         }
@@ -258,7 +260,8 @@ struct PerExtruderAdjustments
                 //test to never go over max_time
                 if (line.time > line.time_max) {
                     line.time = line.time_max;
-                    line.feedrate = line.length / line.time;
+                    if (line.time > 0.f)
+                        line.feedrate = line.length / line.time;
                 }
                 line.slowdown = true;
             }
@@ -725,7 +728,11 @@ static inline float extruder_range_slow_down_proportional(
         // The following step is a linear programming task due to the minimum movement speeds of the print moves.
         // Run maximum 5 iterations until a good enough approximation is reached.
         for (size_t iter = 0; iter < 5; ++ iter) {
-            float factor = (slowdown_below_layer_time - non_adjustable_time) / (total_after_slowdown - non_adjustable_time);
+            float denom = total_after_slowdown - non_adjustable_time;
+            assert(denom > 0.f);
+            if (denom <= 0.f)
+                break;
+            float factor = (slowdown_below_layer_time - non_adjustable_time) / denom;
             assert(factor > 1.f);
             total_after_slowdown = elapsed_time_total0;
             for (auto it = it_begin; it != it_end; ++ it)
@@ -742,7 +749,11 @@ static inline float extruder_range_slow_down_proportional(
         for (auto it = it_begin; it != it_end; ++ it)
             non_adjustable_time += (*it)->non_adjustable_time(true);
         for (size_t iter = 0; iter < 5; ++ iter) {
-            float factor = (slowdown_below_layer_time - non_adjustable_time) / (total_after_slowdown - non_adjustable_time);
+            float denom = total_after_slowdown - non_adjustable_time;
+            assert(denom > 0.f);
+            if (denom <= 0.f)
+                break;
+            float factor = (slowdown_below_layer_time - non_adjustable_time) / denom;
             assert(factor > 1.f);
             total_after_slowdown = elapsed_time_total0;
             for (auto it = it_begin; it != it_end; ++ it)
@@ -802,6 +813,8 @@ static inline void extruder_range_slow_down_non_proportional(
                 for (auto it = adj; it != by_min_print_speed.end(); ++ it)
                     time_adjustable += (*it)->adjustable_time(true);
                 assert(time_adjustable > 0);
+                if (time_adjustable <= 0.f)
+                    return;
                 float rate = (time_adjustable + time_stretch) / time_adjustable;
                 for (auto it = adj; it != by_min_print_speed.end(); ++ it)
                     (*it)->slow_down_proportional(rate, true);


### PR DESCRIPTION
[CWE-369: Division by Zero](https://cwe.mitre.org/data/definitions/369.html)

Fixes division by zero crashes in `CoolingBuffer` when elapsed time is zero, preventing invalid G-code speeds like "F-2147483648".

- Add checks for zero elapsed time before division in three locations
- Use defense-in-depth pattern: assert + runtime check

**Defense in Depth Pattern:**
```cpp
assert(line.time > 0);     // Debug: alerts developer to investigate root cause
if (line.time > 0.f)       // Release: prevents crash, leaves feedrate unchanged
    line.feedrate = line.length / line.time;
```

Source OrcaSlicer [6feb9](https://github.com/OrcaSlicer/OrcaSlicer/commit/6feb99bd2d428b3fc88e916b9ff5a2cae367a1bd) & https://github.com/OrcaSlicer/OrcaSlicer/pull/10944