### PR TITLE
Fix crash with empty instances in AMF import

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -488,7 +488,7 @@ bool Model::looks_like_multipart_object() const
         BoundingBoxf3 bb_this = obj->volumes[0]->mesh().bounding_box();
 
         // FIXME: There is sadly the case when instances are empty (AMF files). The normalization of instances in that
-        // case is performed only after this function is called. For now (shortly before the 2.7.2 release, let's
+        // case is performed only after this function is called. For now (shortly before the 2.7.2 release), let's
         // just do this non-invasive check. Reordering all the functions could break it much more.
         BoundingBoxf3 tbb_this = (! obj->instances.empty() ? obj->instances[0]->transform_bounding_box(bb_this) : bb_this);
 

--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -486,7 +486,11 @@ bool Model::looks_like_multipart_object() const
             return false;
 
         BoundingBoxf3 bb_this = obj->volumes[0]->mesh().bounding_box();
-        BoundingBoxf3 tbb_this = obj->instances[0]->transform_bounding_box(bb_this);
+
+        // FIXME: There is sadly the case when instances are empty (AMF files). The normalization of instances in that
+        // case is performed only after this function is called. For now (shortly before the 2.7.2 release, let's
+        // just do this non-invasive check. Reordering all the functions could break it much more.
+        BoundingBoxf3 tbb_this = (! obj->instances.empty() ? obj->instances[0]->transform_bounding_box(bb_this) : bb_this);
 
         if (!tbb.defined)
             tbb = tbb_this;


### PR DESCRIPTION
[CWE-476: NULL Pointer Dereference](https://cwe.mitre.org/data/definitions/476.html)

Fixes crash when importing AMF files with empty instance arrays. Adds validation check before accessing first instance to compute transformed bounding boxes.

- Check `!obj->instances.empty()` before accessing `instances[0]`
- Use untransformed bounding box if instances array is empty
- Defensive workaround since AMF normalization happens later


PrusaSlicer commit [15987](https://github.com/prusa3d/PrusaSlicer/commit/159875940022c3bad08eb341dbbf596235718605) https://github.com/prusa3d/PrusaSlicer/issues/12332