### PR TITLE
Add infinity protection in BBS3MF parser

### DIFF
--- a/src/libslic3r/Format/bbs_3mf.cpp
+++ b/src/libslic3r/Format/bbs_3mf.cpp
@@ -682,7 +682,8 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
     std::vector<float>        m_filament_densities          = result->filament_densities;
     auto get_used_filament_from_volume = [m_filament_diameters, m_filament_densities](double volume, int extruder_id) {
         double                    koef = 0.001;
-        std::pair<double, double> ret = {koef * volume / (PI * sqr(0.5 * m_filament_diameters[extruder_id])), volume * m_filament_densities[extruder_id] * 0.001};
+        double                    section_area = PI * sqr(0.5 * m_filament_diameters[extruder_id]);
+        std::pair<double, double> ret = {section_area < EPSILON ? 0 : (koef * volume / section_area), volume * m_filament_densities[extruder_id] * 0.001};
         return ret;
     };
 


### PR DESCRIPTION
[CWE-369: Division by Zero](https://cwe.mitre.org/data/definitions/369.html)

Adds validation to prevent division by zero when filament diameter is zero in BBS3MF parser.

Changes:
- Calculate section_area separately before division
- Check if `section_area < EPSILON` before division
- Return 0 for filament length if diameter is invalid
- Still calculate weight `(volume * density)` even with invalid diameter

Technical Details:
- section_area = π * (diameter/2)²
- When diameter is 0, section_area is 0, causing division by zero
- Filament length = volume / section_area (undefined when section_area = 0)
- Filament weight = volume * density (still valid)

OrcaSlicer [9744d93](https://github.com/SoftFever/OrcaSlicer/commit/9744d93)