### PR TITLE
Fix dangling reference in `GUI_App::get_last_mode_btn_color()`

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2414,9 +2414,10 @@ std::string GUI_App::get_first_mode_btn_color(ConfigOptionMode mode_id) const
 std::string GUI_App::get_last_mode_btn_color(ConfigOptionMode mode_id) const
 {
     assert(0 <= size_t(mode_id));
-    assert(size_t(mode_id)< get_app_config()->tags().size());
-    for (size_t idx_p1 = get_app_config()->tags().size(); idx_p1 > 0; --idx_p1) {
-        const AppConfig::Tag& tag = get_app_config()->tags()[idx_p1-1];
+    const auto& tags = get_app_config()->tags();
+    assert(size_t(mode_id) < tags.size());
+    for (size_t idx_p1 = tags.size(); idx_p1 > 0; --idx_p1) {
+        const AppConfig::Tag& tag = tags[idx_p1-1];
         // get the first good tag.
         if ((tag.tag & mode_id) == tag.tag) {
             // store the pointer so we can return a valid reference.


### PR DESCRIPTION
[CWE-825: Expired Pointer Dereference](https://cwe.mitre.org/data/definitions/825.html)

Fixes dangling reference in `GUI_App` by caching tags vector outside loop, ensuring proper lifetime management.

Changes:
- Move `tags` declaration outside loop to prevent repeated temporary copies
- Use cached reference for loop condition and element access  

Details:
- `get_app_config()->tags()` returns `std::vector<Tag>` by value (not reference)
- Original code created temporary on every loop iteration, then took reference to it
- Reference became dangling when temporary was destroyed at end of iteration
- Cache vector once outside loop, use reference throughout