### PR TITLE
Fix buffer overflow in 3MF export

### DIFF
--- a/src/libslic3r/Format/3mf.cpp
+++ b/src/libslic3r/Format/3mf.cpp
@@ -3426,20 +3426,18 @@ namespace Slic3r {
     {
         assert(is_decimal_separator_point());
         std::string out = "";
-        char buffer[1024];
 
         unsigned int count = 0;
         for (const ModelObject* object : model.objects) {
             ++count;
             const std::vector<double>& layer_height_profile = object->layer_height_profile.get();
             if (layer_height_profile.size() >= 4 && layer_height_profile.size() % 2 == 0) {
-                sprintf(buffer, "object_id=%d|", count);
-                out += buffer;
+                out += "object_id=" + std::to_string(count) + "|";
 
                 // Store the layer height profile as a single semicolon separated list.
                 for (size_t i = 0; i < layer_height_profile.size(); ++i) {
-                    sprintf(buffer, (i == 0) ? "%f" : ";%f", layer_height_profile[i]);
-                    out += buffer;
+                    if (i > 0) out += ";";
+                    out += std::to_string(layer_height_profile[i]);
                 }
                 
                 out += "\n";


### PR DESCRIPTION
[CWE-120: Buffer Overflow](https://cwe.mitre.org/data/definitions/120.html)

Replaces unsafe `sprintf` with `std::to_string` to prevent buffer overflow in 3MF export.

Changes:
- Replace `sprintf` with `std::to_string` for layer height profile export
- Eliminates 1024-byte fixed buffer that could overflow with large datasets

Details:
- Original code used fixed 1024-byte buffer with `sprintf`
- Large layer height profiles could overflow buffer
- `std::to_string` uses default precision (6 digits) which is sufficient
- 3MF parser handles various float formats