### PR TITLE
Fix integer overflow in Point multiplication

### DIFF
--- a/src/libslic3r/Point.hpp
+++ b/src/libslic3r/Point.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <sstream>
 #include <unordered_map>
+#include <limits>
 
 #include <oneapi/tbb/scalable_allocator.h>
 

--- a/src/libslic3r/Point.hpp
+++ b/src/libslic3r/Point.hpp
@@ -293,7 +293,11 @@ public:
 
     Point& operator+=(const Point& rhs) { this->x() += rhs.x(); this->y() += rhs.y(); return *this; }
     Point& operator-=(const Point& rhs) { this->x() -= rhs.x(); this->y() -= rhs.y(); return *this; }
-	Point& operator*=(const double &rhs) { this->x() = coord_t(this->x() * rhs); this->y() = coord_t(this->y() * rhs); return *this; }
+	Point& operator*=(const double &rhs) { 
+        this->x() = coord_t(std::clamp(this->x() * rhs, double(std::numeric_limits<coord_t>::min()), double(std::numeric_limits<coord_t>::max()))); 
+        this->y() = coord_t(std::clamp(this->y() * rhs, double(std::numeric_limits<coord_t>::min()), double(std::numeric_limits<coord_t>::max()))); 
+        return *this; 
+    }
     //Point operator*(const double &rhs) const { return Point(this->x() * rhs, this->y() * rhs); } //already exist outside
 
     void   rotate(double angle) { this->rotate(std::cos(angle), std::sin(angle)); }
@@ -330,7 +334,10 @@ inline bool operator<(const Point &l, const Point &r)
 
 inline Point operator* (const Point& l, const double &r)
 {
-    return {coord_t(l.x() * r), coord_t(l.y() * r)};
+    return {
+        coord_t(std::clamp(l.x() * r, double(std::numeric_limits<coord_t>::min()), double(std::numeric_limits<coord_t>::max()))),
+        coord_t(std::clamp(l.y() * r, double(std::numeric_limits<coord_t>::min()), double(std::numeric_limits<coord_t>::max())))
+    };
 }
 
 inline bool is_approx(const Point &p1, const Point &p2, coord_t epsilon = coord_t(SCALED_EPSILON))


### PR DESCRIPTION
[CWE-190: Integer Overflow](https://cwe.mitre.org/data/definitions/190.html)

Adds `std::clamp` to prevent integer overflow in Point coordinate multiplication.

Changes:
- Use `std::clamp` to limit results to `coord_t` range (`INT32_MIN` to `INT32_MAX`)
- Apply to `operator*=` for both `Point` and `Point3` classes
- Prevents geometry corruption from integer wraparound

Details:
- `coord_t` is `int32_t` (range: ±2.1B)
- Multiplying large coordinates can overflow
- Clamping prevents wraparound while preserving direction