### PR TITLE
Fix the crash during inserting tool preheat g-codes.

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -4418,8 +4418,10 @@ void GCodeProcessor::post_process()
                     m_statistics.add_line(out_line.length());
 #endif // NDEBUG
                     m_size += out_line.length();
+
                     // synchronize gcode lines map
-                    for (auto map_it = m_gcode_lines_map.rbegin(); map_it != m_gcode_lines_map.rbegin() + rev_it_dist - 1; ++map_it) {
+                    const auto map_end_it = rev_it_dist <= m_gcode_lines_map.size() ? m_gcode_lines_map.rbegin() + (rev_it_dist - 1) : m_gcode_lines_map.rend();
+                    for (auto map_it = m_gcode_lines_map.rbegin(); map_it != map_end_it; ++map_it) {
                         ++map_it->second;
                     }
 


### PR DESCRIPTION
[CWE-476: NULL Pointer Dereference](https://cwe.mitre.org/data/definitions/476.html)

Fixes crash when inserting tool preheat g-codes by adding iterator bounds checking.

Changes:
- Add bounds check to prevent iterator overflow in gcode lines map
- Check that `rev_it_dist < m_gcode_lines_map.size()` before access
- Prevents crash during post-processing synchronization

Details:
- Crash occurs when `rev_it_dist` exceeds size of `m_gcode_lines_map`
- Iterator arithmetic can go out of bounds during line synchronization
- Bounds check prevents invalid iterator dereference

PrusaSlicer commit [bfdfc](https://github.com/prusa3d/PrusaSlicer/commit/bfdfcb3a270c2b0210e45da0066f6b87ae6b17e8)