### PR TITLE
Fix division by zero in `AABBTreeLines` ray intersection

### DIFF
--- a/src/libslic3r/AABBTreeLines.hpp
+++ b/src/libslic3r/AABBTreeLines.hpp
@@ -78,6 +78,9 @@ inline std::tuple<int, int> coordinate_aligned_ray_hit_count(size_t             
             //  Note that ray and line may overlap, when  (line.b[oc] - line.a[oc]) is zero
             //  In that case, we return negative number
             Floating distance_oc = line.b[other_coordinate] - line.a[other_coordinate];
+            if (std::abs(distance_oc) < EPSILON) {
+                return {-1, 0};
+            }
             Floating t     = (ray_origin[other_coordinate] - line.a[other_coordinate]) / distance_oc;
             Floating val_c = line.a[coordinate] + t * (line.b[coordinate] - line.a[coordinate]);
             if (ray_origin[coordinate] > val_c) {

--- a/src/libslic3r/AABBTreeLines.hpp
+++ b/src/libslic3r/AABBTreeLines.hpp
@@ -76,13 +76,16 @@ inline std::tuple<int, int> coordinate_aligned_ray_hit_count(size_t             
             //  then we want to get value of intersection[ coordinate]
             //  val_c = line.a[c] + t * (line.b[c] - line.a[c]);
             //  Note that ray and line may overlap, when  (line.b[oc] - line.a[oc]) is zero
-            //  In that case, we return negative number
+            //  In that case, we use line.a as the intersection point
             Floating distance_oc = line.b[other_coordinate] - line.a[other_coordinate];
-            if (std::abs(distance_oc) < EPSILON) {
-                return {-1, 0};
+            Floating val_c;
+            if (std::abs(distance_oc) < (std::is_floating_point<Scalar>::value ? EPSILON : SCALED_EPSILON)) {
+                // Line is nearly degenerate (parallel to ray), use line.a as intersection point
+                val_c = line.a[coordinate];
+            } else {
+                Floating t = (ray_origin[other_coordinate] - line.a[other_coordinate]) / distance_oc;
+                val_c = line.a[coordinate] + t * (line.b[coordinate] - line.a[coordinate]);
             }
-            Floating t     = (ray_origin[other_coordinate] - line.a[other_coordinate]) / distance_oc;
-            Floating val_c = line.a[coordinate] + t * (line.b[coordinate] - line.a[coordinate]);
             if (ray_origin[coordinate] > val_c) {
                 return {1, 0};
             } else if (ray_origin[coordinate] < val_c) {


### PR DESCRIPTION
[CWE-369: Division by Zero](https://cwe.mitre.org/data/definitions/369.html)

Fixes division by zero in `AABBTreeLines` when segment length is zero.

Changes:
- Check segment length before division
- Use assert + runtime check
- Skip zero-length segments gracefully

Details:
- Degenerate geometry can have zero-length edges
- Division by zero would crash during tree construction
- Runtime check prevents crash, assert helps debugging