### PR TITLE
Fix buffer overflow in 3MF error messages

### DIFF
--- a/src/libslic3r/Format/3mf.cpp
+++ b/src/libslic3r/Format/3mf.cpp
@@ -1170,9 +1170,10 @@ namespace Slic3r {
             res = mz_zip_reader_extract_to_callback(&archive, stat.m_file_index, [](void* pOpaque, mz_uint64 file_ofs, const void* pBuf, size_t n)->size_t {
                 CallbackData* data = (CallbackData*)pOpaque;
                 if (!XML_Parse(data->parser, (const char*)pBuf, (int)n, (file_ofs + n == data->stat.m_uncomp_size) ? 1 : 0) || data->importer.parse_error()) {
-                    char error_buf[1024];
-                    ::sprintf(error_buf, "Error (%s) while parsing '%s' at line %d", data->importer.parse_error_message(), data->stat.m_filename, (int)XML_GetCurrentLineNumber(data->parser));
-                    throw Slic3r::FileIOError(error_buf);
+                    std::string error_msg = "Error (" + std::string(data->importer.parse_error_message()) +
+                                           ") while parsing '" + std::string(data->stat.m_filename) +
+                                           "' at line " + std::to_string((int)XML_GetCurrentLineNumber(data->parser));
+                    throw Slic3r::FileIOError(error_msg);
                 }
 
                 return n;
@@ -1640,9 +1641,9 @@ namespace Slic3r {
         }
 
         if (!XML_ParseBuffer(m_xml_parser, (int)stat.m_uncomp_size, 1)) {
-            char error_buf[1024];
-            ::sprintf(error_buf, "Error (%s) while parsing xml file at line %d", XML_ErrorString(XML_GetErrorCode(m_xml_parser)), (int)XML_GetCurrentLineNumber(m_xml_parser));
-            add_error(error_buf);
+            std::string error_msg = "Error (" + std::string(XML_ErrorString(XML_GetErrorCode(m_xml_parser))) +
+                                   ") while parsing xml file at line " + std::to_string((int)XML_GetCurrentLineNumber(m_xml_parser));
+            add_error(error_msg);
             return false;
         }
 


### PR DESCRIPTION
[CWE-120: Buffer Overflow](https://cwe.mitre.org/data/definitions/120.html)

Replace unsafe `sprintf` calls that write to fixed 1024-byte buffers with safe `std::string` concatenation, eliminating the risk of buffer overflow when XML parser error messages exceed the buffer size.

**Changes:**
- Replaced `sprintf` with `std::string` concatenation in XML parsing error handling
- Eliminated fixed-size char buffers (1024 bytes) that could overflow with unbounded XML error messages
- Prevents overflow with long filenames or error messages

Details:
- `sprintf` has no bounds checking
- Long filenames could overflow fixed buffer