### PR TITLE
Fix division by zero in `SkeletalTrapezoidation` edge discretization

### DIFF
--- a/src/libslic3r/Arachne/SkeletalTrapezoidation.cpp
+++ b/src/libslic3r/Arachne/SkeletalTrapezoidation.cpp
@@ -248,6 +248,13 @@ Points SkeletalTrapezoidation::discretize(const VD::edge_type& vd_edge, const st
         Point   left_point    = Geometry::VoronoiUtils::get_source_point(*left_cell, segments.begin(), segments.end());
         Point   right_point   = Geometry::VoronoiUtils::get_source_point(*right_cell, segments.begin(), segments.end());
         coord_t d             = (right_point - left_point).cast<int64_t>().norm();
+        
+        // Handle degenerate case where left and right points are the same
+        if (d == 0) {
+            // Return start and end points for consistency with line 235
+            return Points({ start, end });
+        }
+        
         Point   middle        = (left_point + right_point) / 2;
         Point   x_axis_dir    = perp(Point(right_point - left_point));
         coord_t x_axis_length = x_axis_dir.cast<int64_t>().norm();


### PR DESCRIPTION
[CWE-369: Division by Zero](https://cwe.mitre.org/data/definitions/369.html)

Fixes division by zero in `SkeletalTrapezoidation` when edge points are coincident.

Changes:
- Check if `x_axis_length` is zero before division
- Return `Points({ start, end })`
- Prevents crash when `left_point` equals `right_point`

Details:
- `x_axis_length` becomes 0 when points are coincident (degenerate edge)
- Division by zero in `projected_x` lambda would crash
- Caller expects at least 2 points in return value