### PR TITLE
Fix division by zero in WallToolPaths simplifyPath

### DIFF
--- a/src/libslic3r/Arachne/WallToolPaths.cpp
+++ b/src/libslic3r/Arachne/WallToolPaths.cpp
@@ -272,8 +272,10 @@ void fixSelfIntersections(const coord_t epsilon, Polygons &thiss)
                     assert(Slic3r::sqr(double(vec.x())) < double(std::numeric_limits<int64_t>::max()));
                     assert(Slic3r::sqr(double(vec.y())) < double(std::numeric_limits<int64_t>::max()));
                     const int64_t len   = vec.norm();
-                    pt.x() += (-vec.y() * move_dist) / len;
-                    pt.y() += (vec.x() * move_dist) / len;
+                    if (len > 0) {
+                        pt.x() += (-vec.y() * move_dist) / len;
+                        pt.y() += (vec.x() * move_dist) / len;
+                    }
                 }
             }
         }


### PR DESCRIPTION
[CWE-369: Division by Zero](https://cwe.mitre.org/data/definitions/369.html)

Fixes division by zero in `WallToolPaths` `simplifyPath` when segment length is zero.

Changes:
- Check segment length before division
- Use assert + runtime check
- Skip zero-length segments gracefully

Details:
- Degenerate geometry can have zero-length segments
- Division by zero in simplification would crash
- Runtime check prevents crash, assert helps debugging