### PR TITLE
Fix unchecked `fread()` return values in `exif.c`

### DIFF
--- a/src/exif/exif.c
+++ b/src/exif/exif.c
@@ -246,8 +246,14 @@ int exif_removeExifSegmentFromJPEGFile(const char *inJPEGFileName,
     }
     if (!p) {
         for (i = 0; i < App1StartOffset; i++) {
-            fread(buf, 1, sizeof(char), fpr);
-            fwrite(buf, 1, sizeof(char), fpw);
+            if (fread(buf, 1, sizeof(char), fpr) != sizeof(char)) {
+                sts = EXIF_ERR_READ_FILE;
+                goto DONE;
+            }
+            if (fwrite(buf, 1, sizeof(char), fpw) < sizeof(char)) {
+                sts = EXIF_ERR_WRITE_FILE;
+                goto DONE;
+            }
         }
     } else {
         if (fread(p, 1, App1StartOffset, fpr) < (size_t)App1StartOffset) {
@@ -1249,8 +1255,14 @@ int EXIF_API_EXPORT exif_updateExifSegmentInJPEGFile(const char *inJPEGFileName,
     }
     if (!p) {
         for (i = 0; i < ofs; i++) {
-            fread(buf, 1, sizeof(char), fpr);
-            fwrite(buf, 1, sizeof(char), fpw);
+            if (fread(buf, 1, sizeof(char), fpr) != sizeof(char)) {
+                sts = EXIF_ERR_READ_FILE;
+                goto DONE;
+            }
+            if (fwrite(buf, 1, sizeof(char), fpw) < sizeof(char)) {
+                sts = EXIF_ERR_WRITE_FILE;
+                goto DONE;
+            }
         }
     } else {
         if (fread(p, 1, ofs, fpr) < (size_t)ofs) {
@@ -1362,8 +1374,14 @@ int EXIF_API_EXPORT exif_removeAdobeMetadataSegmentFromJPEGFile(const char *inJP
     }
     if (!p) {
         for (i = 0; i < (int)ofs; i++) {
-            fread(buf, 1, sizeof(char), fpr);
-            fwrite(buf, 1, sizeof(char), fpw);
+            if (fread(buf, 1, sizeof(char), fpr) != sizeof(char)) {
+                sts = EXIF_ERR_READ_FILE;
+                goto DONE;
+            }
+            if (fwrite(buf, 1, sizeof(char), fpw) < sizeof(char)) {
+                sts = EXIF_ERR_WRITE_FILE;
+                goto DONE;
+            }
         }
     } else {
         if (fread(p, 1, ofs, fpr) < (size_t)ofs) {


### PR DESCRIPTION
[CWE-252: Unchecked Return Value](https://cwe.mitre.org/data/definitions/252.html)

Fixes unchecked `fread()` and `fwrite()` return values in `exif.c` that could cause data corruption.

Changes:
- Check `fread()` return values at 3 locations
- Check `fwrite()` return values at 3 locations
- Handle errors with proper error codes and cleanup

Details:
- `fread()` returns bytes read, may be less than requested on error/EOF
- `fwrite()` returns bytes written, may be less on disk full/error
- Using uninitialized data from failed reads causes corruption
- Use `< sizeof(char)` for `fwrite` (consistent with existing code style)