### PR TITLE
Fix logical NOT precedence in `Flow.cpp` spacing check

### DIFF
--- a/src/libslic3r/Flow.cpp
+++ b/src/libslic3r/Flow.cpp
@@ -310,7 +310,7 @@ Flow Flow::new_from_config(FlowRole role, const DynamicConfig& print_config, flo
         config_width.set(*print_config.option("external_perimeter_extrusion_width"));
         config_spacing.set(*print_config.option("external_perimeter_extrusion_spacing"));
         // external peri spacing is only half spacing -> transform it into a full spacing
-        if (!config_spacing.is_phony() && !config_spacing.value == 0) {
+        if (!config_spacing.is_phony() && config_spacing.value != 0) {
             double raw_spacing = config_spacing.get_abs_value(nozzle_diameter);
             config_spacing.percent = false;
             config_spacing.value = rounded_rectangle_extrusion_spacing(


### PR DESCRIPTION
[CWE-480: Use of Incorrect Operator](https://cwe.mitre.org/data/definitions/480.html)

Fixes logical operator precedence bug in Flow.cpp external perimeter spacing calculation.

Bug: `!config_spacing.value == 0` evaluates as `(!config_spacing.value) == 0` due to operator precedence, causing wrong logic.

Fix: Changed to `config_spacing.value != 0` for correct evaluation.

Details:
- Operator `!` has higher precedence than `==`
- `!config_spacing.value == 0` means "NOT config_spacing.value, then compare to 0"
- Should be `config_spacing.value NOT EQUAL to 0`
- Bug causes incorrect external perimeter spacing when value is non-zero