### PR TITLE
Fix logical NOT precedence in `PrintConfig.cpp` substitution check

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -10221,7 +10221,7 @@ void _deserialize_maybe_from_prusa(const std::map<t_config_option_key, std::stri
                         }
                     }
                 }
-            } else if (def != nullptr && !config_substitutions.rule == ForwardCompatibilitySubstitutionRule::Disable) {
+            } else if (def != nullptr && config_substitutions.rule != ForwardCompatibilitySubstitutionRule::Disable) {
                 const ConfigOptionDef *optdef = def->get(key);
                 if (optdef != nullptr) {
                     config_substitutions.emplace(optdef, std::string(pair.second), ConfigOptionUniquePtr(optdef->default_value->clone()));


### PR DESCRIPTION
[CWE-480: Use of Incorrect Operator](https://cwe.mitre.org/data/definitions/480.html)

Fixes logical operator precedence bug in `PrintConfig.cpp` config substitution check.

Bug: `!config_substitutions.rule == Disable` evaluates as `(!config_substitutions.rule) == Disable` due to operator precedence, causing wrong logic.

Fix: Changed to `config_substitutions.rule != ForwardCompatibilitySubstitutionRule::Disable` for correct evaluation.

Details:
- Operator `!` has higher precedence than `==`
- `!rule == Disable` means "NOT rule, then compare to Disable"
- Should be `rule NOT EQUAL to Disable`
- Bug causes incorrect config substitution behavior when loading files