### PR TITLE
Fix buffer overflow in `debug_out_path` functions

### DIFF
--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -273,7 +273,7 @@ std::string debug_out_path(const char *name, ...)
     char buffer[2048];
     va_list args;
     va_start(args, name);
-    std::vsprintf(buffer, name, args);
+    std::vsnprintf(buffer, sizeof(buffer), name, args);
     va_end(args);
     return std::string(SLIC3R_DEBUG_OUT_PATH_PREFIX) + std::string(buffer);
 }
@@ -298,7 +298,7 @@ std::string debug_out_path_uniqueid(std::string name, ...) {
     va_list args;
     va_start(args, name);
     //name = debug_out_path(name.c_str(), args);
-    std::vsprintf(buffer, name.c_str(), args);
+    std::vsnprintf(buffer, sizeof(buffer), name.c_str(), args);
     va_end(args);
     return std::string(SLIC3R_DEBUG_OUT_PATH_PREFIX) + std::string(buffer);
 }


### PR DESCRIPTION
[CWE-120: Buffer Overflow](https://cwe.mitre.org/data/definitions/120.html)

Replaces unsafe vsprintf with vsnprintf to prevent buffer overflow in debug functions.

Changes:
- Replace `vsprintf` with `vsnprintf` in `debug_out_path` (line 276)
- Replace `vsprintf` with `vsnprintf` in `debug_out_path_uniqueid` (line 301)
- Add explicit 2048-byte buffer size limit

Details:
- `vsprintf` has no bounds checking
- Long paths could overflow 2048-byte buffer
- vsnprintf truncates safely at buffer limit
- Debug code only, not in production paths