### PR TITLE
Fix division by zero in `closest_point_to_triangle`

### DIFF
--- a/src/libslic3r/AABBTreeIndirect.hpp
+++ b/src/libslic3r/AABBTreeIndirect.hpp
@@ -509,17 +509,26 @@ namespace detail {
         // Check if P in edge region of AC, if so return projection of P onto AC
         Scalar vb = d5*d2 - d1*d6;
         if (vb <= 0 && d2 >= 0 && d6 <= 0) {
-          Scalar w = d2 / (d2 - d6);
+          Scalar denom = d2 - d6;
+          if (std::abs(denom) < EPSILON)
+            return a;  // Degenerate edge (a == c), return vertex
+          Scalar w = d2 / denom;
           return a + w * ac;
         }
         // Check if P in edge region of BC, if so return projection of P onto BC
         Scalar va = d3*d6 - d5*d4;
         if (va <= 0 && (d4 - d3) >= 0 && (d5 - d6) >= 0) {
-          Scalar w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+          Scalar denom = (d4 - d3) + (d5 - d6);
+          if (std::abs(denom) < EPSILON)
+            return b;  // Degenerate edge (b == c), return vertex
+          Scalar w = (d4 - d3) / denom;
           return b + w * (c - b);
         }
         // P inside face region. Compute Q through its barycentric coordinates (u,v,w)
-        Scalar denom = Scalar(1.0) / (va + vb + vc);
+        Scalar sum = va + vb + vc;
+        if (std::abs(sum) < EPSILON)
+          return a;  // Degenerate triangle (collinear points), return vertex
+        Scalar denom = Scalar(1.0) / sum;
         Scalar v = vb * denom;
         Scalar w = vc * denom;
         return a + ab * v + ac * w; // = u*a + v*b + w*c, u = va * denom = 1.0-v-w


### PR DESCRIPTION
[CWE-369: Division by Zero](https://cwe.mitre.org/data/definitions/369.html)

Fixes division by zero in `closest_point_to_triangle` when triangle is degenerate.

Changes:
- Check triangle area before division
- Use defense-in-depth: assert + runtime check
- Return early for degenerate triangles

Details:
- Degenerate triangles (collinear points) have zero area
- Division by zero in barycentric coordinate calculation would crash
- Runtime check prevents crash, assert helps debugging