### PR TITLE
Prevent segfault on linux a few seconds after start

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7393,7 +7393,11 @@ std::string GCodeGenerator::_before_extrude(const ExtrusionPath &path, const std
     // compensate retraction
     if (m_delayed_layer_change.empty()) {
         gcode += m_writer.unlift();//this->unretract();
+#ifdef _DEBUGINFO
         assert(is_approx(m_writer.get_position().z(), m_layer->print_z, EPSILON) || m_loop_vase_mode);
+#else
+        assert(is_approx(m_writer.get_position().z(), m_layer->print_z, EPSILON));
+#endif
     } else {
         //check if an unlift happens
         std::string unlift = m_writer.unlift();
@@ -7955,7 +7959,11 @@ void GCodeGenerator::write_travel_to(std::string &gcode, Polyline& travel, std::
         this->writer().set_lift(this->writer().get_position().z() - *m_new_z_target);
         m_new_z_target.reset();
     }
+#ifdef _DEBUGINFO
     assert(!m_layer || is_approx(this->writer().get_unlifted_position().z(), m_layer->print_z, EPSILON) || comment == "Travel to a Wipe Tower" || m_loop_vase_mode);
+#else
+    assert(!m_layer || is_approx(this->writer().get_unlifted_position().z(), m_layer->print_z, EPSILON) || comment == "Travel to a Wipe Tower");
+#endif
 }
 
 // generate a travel in xyz

--- a/src/semver/semver.c
+++ b/src/semver/semver.c
@@ -314,9 +314,11 @@ semver_compare_prerelease (semver_t x, semver_t y) {
 
 int
 semver_compare_version (semver_t x, semver_t y) {
-  int res = binary_comparison(x.counter_size, y.counter_size);
+  int x_size = (x.counters != NULL) ? x.counter_size : 0;
+  int y_size = (y.counters != NULL) ? y.counter_size : 0;
+  int res = binary_comparison(x_size, y_size);
 
-  for (int i = 0; i < x.counter_size && i < y.counter_size; i++) {
+  for (int i = 0; i < x_size && i < y_size; i++) {
       if ((res = binary_comparison(x.counters[i], y.counters[i])) != 0)
           return res;
   }
@@ -688,8 +690,10 @@ semver_copy(const semver_t *ver) {
   if (ver->prerelease != NULL) {
       res.prerelease = strdup(ver->prerelease);
   }
-  if (ver->counters) {
+  if (ver->counters != NULL) {
       res.counters = semver_intdup(ver->counters, ver->counter_size);
+      if (res.counters == NULL)
+          res.counter_size = 0;
   }
   return res;
 }


### PR DESCRIPTION
Made a debug build, attached gdb and found this issue in `semver.c`.

I couldn't get i to crash anymore.