### PR TITLE
SET_PRESSURE_ADVANCE should account for single_extruder_multi_material

### DIFF
--- a/src/libslic3r/GCode/GCodeWriter.cpp
+++ b/src/libslic3r/GCode/GCodeWriter.cpp
@@ -236,7 +236,7 @@ std::string GCodeWriter::write_pressure_advance(double pa) {
         }
     } else if (FLAVOR_IS(gcfKlipper)) {
         gcode = std::string("SET_PRESSURE_ADVANCE ADVANCE=") + to_string_nozero(pa, 4);
-        if (this->config.tool_name.size() > tool_id && !this->config.tool_name.get_at(tool_id).empty()) {
+        if (!this->config.single_extruder_multi_material.value && this->config.tool_name.size() > tool_id && !this->config.tool_name.get_at(tool_id).empty()) {
             gcode += std::string(" EXTRUDER=") + this->config.tool_name.get_at(tool_id);
             } else if(tool_id > 0){
                 gcode += std::string(" EXTRUDER=extruder") + std::to_string(tool_id);


### PR DESCRIPTION
In Klipper, when using a single extruder MMU setup, if the pressure advance value for different filaments are used, the gcode generated when slicing includes the GCODE `SET_PRESSURE_ADVANCE [...] EXTRUDER=extruderX` which causes errors in Klipper since the machine won't recognize different extruders other than the single/default `extruder`. 

As a workaround, i found out you can use the extruder name to set it to `extruder` in all the extruders so this name will be used instead of the `extruder{1-N}` value.